### PR TITLE
Enable active directory accounts

### DIFF
--- a/app/ADUpdateRequest.php
+++ b/app/ADUpdateRequest.php
@@ -19,7 +19,6 @@ class ADUpdateRequest extends Model
     public const ACTIVATION_TYPE = 'enable';
     public const DEACTIVATION_TYPE = 'disable';
 
-    public const STATUS_NOT_DONE = 'not_done';
     public const STATUS_SUCCESS = 'success';
 
     protected $fillable = [

--- a/app/ADUpdateRequest.php
+++ b/app/ADUpdateRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Class ADUpdateRequest
+ * @package App
+ * @property string type
+ * @property int customer_id
+ * @property Customer customer
+ */
+class ADUpdateRequest extends Model
+{
+    protected $table = "ad_update_requests";
+
+    public const ACTIVATION_TYPE = 'enable';
+    public const DEACTIVATION_TYPE = 'disable';
+
+    public const STATUS_NOT_DONE = 'not_done';
+    public const STATUS_SUCCESS = 'success';
+
+    protected $fillable = [
+        'type',
+        'customer_id',
+    ];
+
+    public function customer()
+    {
+        return $this->belongsTo(Customer::class, 'customer_id', 'woo_id');
+    }
+}

--- a/app/ADUpdateRequest.php
+++ b/app/ADUpdateRequest.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * Class ADUpdateRequest
  * @package App
+ * @property int id
  * @property string type
  * @property int customer_id
  * @property Customer customer

--- a/app/Aggregates/MembershipAggregate.php
+++ b/app/Aggregates/MembershipAggregate.php
@@ -2,6 +2,7 @@
 
 namespace App\Aggregates;
 
+use App\Aggregates\MembershipTraits\ActiveDirectory;
 use App\Aggregates\MembershipTraits\Cards;
 use App\Aggregates\MembershipTraits\Github;
 use App\Aggregates\MembershipTraits\Subscription;
@@ -22,8 +23,9 @@ use Spatie\EventSourcing\AggregateRoot;
 final class MembershipAggregate extends AggregateRoot
 {
     use CustomerBasedAggregate;
-    use Github;
+    use ActiveDirectory;
     use Cards;
+    use Github;
     use Subscription;
 
     public $currentlyAMember = false;
@@ -192,11 +194,13 @@ final class MembershipAggregate extends AggregateRoot
     public function handleMembershipActivated()
     {
         $this->activateCardsNeedingActivation();
+        $this->enableActiveDirectoryAccount();
     }
 
     public function handleMembershipDeactivated()
     {
         $this->deactivateAllCards();
+        $this->disableActiveDirectoryAccount();
     }
 
     protected function applyMembershipActivated()

--- a/app/Aggregates/MembershipTraits/ActiveDirectory.php
+++ b/app/Aggregates/MembershipTraits/ActiveDirectory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Aggregates\MembershipTraits;
+
+
+use App\StorableEvents\ADUserToBeDisabled;
+use App\StorableEvents\ADUserToBeEnabled;
+
+trait ActiveDirectory
+{
+    public function enableActiveDirectoryAccount()
+    {
+        $this->recordThat(new ADUserToBeEnabled($this->customerId));
+    }
+
+    public function disableActiveDirectoryAccount()
+    {
+        $this->recordThat(new ADUserToBeDisabled($this->customerId));
+    }
+}

--- a/app/Aggregates/MembershipTraits/ActiveDirectory.php
+++ b/app/Aggregates/MembershipTraits/ActiveDirectory.php
@@ -3,8 +3,12 @@
 namespace App\Aggregates\MembershipTraits;
 
 
+use App\ADUpdateRequest;
+use App\StorableEvents\ADUserDisabled;
+use App\StorableEvents\ADUserEnabled;
 use App\StorableEvents\ADUserToBeDisabled;
 use App\StorableEvents\ADUserToBeEnabled;
+use Exception;
 
 trait ActiveDirectory
 {
@@ -16,5 +20,30 @@ trait ActiveDirectory
     public function disableActiveDirectoryAccount()
     {
         $this->recordThat(new ADUserToBeDisabled($this->customerId));
+    }
+
+    public function updateADStatus(ADUpdateRequest $updateRequest, $status)
+    {
+        if(! $this->respondToEvents) {
+            return $this;
+        }
+
+        if($status == ADUpdateRequest::STATUS_SUCCESS) {
+            if($updateRequest->type == ADUpdateRequest::ACTIVATION_TYPE) {
+                $this->recordThat(new ADUserEnabled($this->customerId));
+            } else if ($updateRequest->type == ADUpdateRequest::DEACTIVATION_TYPE) {
+                $this->recordThat(new ADUserDisabled($this->customerId));
+            } else {
+                $message = "Active Directory update request type wasn't one of the expected values: "
+                . $updateRequest->type;
+                throw new Exception($message);
+            }
+        } else {
+            $message = "Active Directory update (Customer: $updateRequest->customer_id, "
+                . "Type: $updateRequest->type) not successful";
+            throw new Exception($message);
+        }
+
+        return $this;
     }
 }

--- a/app/Aggregates/MembershipTraits/Cards.php
+++ b/app/Aggregates/MembershipTraits/Cards.php
@@ -42,7 +42,7 @@ trait Cards
         if ($status == CardUpdateRequest::STATUS_SUCCESS) {
             if ($cardUpdateRequest->type == CardUpdateRequest::ACTIVATION_TYPE) {
                 $this->recordThat(new CardActivated($this->customerId, $cardUpdateRequest->card));
-            } elseif ($cardUpdateRequest->type == CardUpdateRequest::DEACTIVATION_TYPE) {
+            } else if ($cardUpdateRequest->type == CardUpdateRequest::DEACTIVATION_TYPE) {
                 $this->recordThat(new CardDeactivated($this->customerId, $cardUpdateRequest->card));
             } else {
                 $message = "Card update request type wasn't one of the expected values: {$cardUpdateRequest->type}";

--- a/app/Http/Controllers/ADUpdateRequestsController.php
+++ b/app/Http/Controllers/ADUpdateRequestsController.php
@@ -3,7 +3,9 @@
 namespace App\Http\Controllers;
 
 use App\ADUpdateRequest;
+use App\Aggregates\MembershipAggregate;
 use App\Http\Resources\ADUpdateRequestResource;
+use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 
 class ADUpdateRequestsController extends Controller
@@ -11,5 +13,19 @@ class ADUpdateRequestsController extends Controller
     public function index(): AnonymousResourceCollection
     {
         return ADUpdateRequestResource::collection(ADUpdateRequest::with('customer')->get());
+    }
+
+    public function updateStatus(Request $request, ADUpdateRequest $cardUpdateRequest)
+    {
+        $status = $request->json('status');
+
+        try {
+            MembershipAggregate::make($cardUpdateRequest->customer_id)
+                ->updateADStatus($cardUpdateRequest, $status)
+                ->persist();
+        } catch (\Throwable $t) {
+            // Swallow the error, the client can't handle it
+            report($t);
+        }
     }
 }

--- a/app/Http/Controllers/ADUpdateRequestsController.php
+++ b/app/Http/Controllers/ADUpdateRequestsController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\ADUpdateRequest;
+use App\Http\Resources\ADUpdateRequestResource;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+
+class ADUpdateRequestsController extends Controller
+{
+    public function index(): AnonymousResourceCollection
+    {
+        return ADUpdateRequestResource::collection(ADUpdateRequest::with('customer')->get());
+    }
+}

--- a/app/Http/Controllers/CardUpdateRequestsController.php
+++ b/app/Http/Controllers/CardUpdateRequestsController.php
@@ -7,10 +7,11 @@ use App\Aggregates\MembershipAggregate;
 use App\CardUpdateRequest;
 use App\Http\Resources\CardUpdateRequestResource;
 use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 
 class CardUpdateRequestsController extends Controller
 {
-    public function index()
+    public function index(): AnonymousResourceCollection
     {
         return CardUpdateRequestResource::collection(CardUpdateRequest::with('customer')->get());
     }

--- a/app/Http/Resources/ADUpdateRequestResource.php
+++ b/app/Http/Resources/ADUpdateRequestResource.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Resources;
+
+use App\ADUpdateRequest;
+use App\Customer;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @property int id
+ * @property string type
+ * @property Customer customer
+ */
+class ADUpdateRequestResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->id,
+            'method' => $this->type,
+            'username' => $this->customer->username,
+            $this->mergeWhen($this->type == ADUpdateRequest::ACTIVATION_TYPE, [
+                'first_name' => $this->customer->first_name,
+                'last_name' => $this->customer->last_name,
+            ]),
+        ];
+    }
+}

--- a/app/Http/Resources/CardUpdateRequestResource.php
+++ b/app/Http/Resources/CardUpdateRequestResource.php
@@ -29,9 +29,11 @@ class CardUpdateRequestResource extends JsonResource
             'method' => $this->getUpdateMethod(),
             'id' => $this->id,
             'card' => $this->card,
-            'first_name' => $this->when($this->type == CardUpdateRequest::ACTIVATION_TYPE, $this->customer->first_name),
-            'last_name' => $this->when($this->type == CardUpdateRequest::ACTIVATION_TYPE, $this->customer->last_name),
             'company' => self::COMPANY_DENHAC,
+            $this->mergeWhen($this->type == CardUpdateRequest::ACTIVATION_TYPE, [
+                'first_name' => $this->customer->first_name,
+                'last_name' => $this->customer->last_name,
+            ]),
         ];
     }
 

--- a/app/Projectors/ADUpdateRequestProjector.php
+++ b/app/Projectors/ADUpdateRequestProjector.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Projectors;
+
+use App\CardUpdateRequest;
+use App\StorableEvents\ADUserToBeEnabled;
+use App\StorableEvents\ADUserToBeDisabled;
+use Spatie\EventSourcing\Projectors\Projector;
+use Spatie\EventSourcing\Projectors\ProjectsEvents;
+
+class ADUpdateRequestProjector implements Projector
+{
+    use ProjectsEvents;
+}

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use App\ADUpdateRequest;
 use App\CardUpdateRequest;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Route;
@@ -27,6 +28,7 @@ class RouteServiceProvider extends ServiceProvider
         parent::boot();
 
         Route::model('card_update_request', CardUpdateRequest::class);
+        Route::model('ad_update_request', ADUpdateRequest::class);
     }
 
     /**

--- a/app/Reactors/ADUpdateRequestReactor.php
+++ b/app/Reactors/ADUpdateRequestReactor.php
@@ -3,6 +3,9 @@
 namespace App\Reactors;
 
 use App\ADUpdateRequest;
+use App\CardUpdateRequest;
+use App\StorableEvents\ADUserDisabled;
+use App\StorableEvents\ADUserEnabled;
 use App\StorableEvents\ADUserToBeDisabled;
 use App\StorableEvents\ADUserToBeEnabled;
 use Spatie\EventSourcing\EventHandlers\EventHandler;
@@ -26,5 +29,19 @@ class ADUpdateRequestReactor implements EventHandler
             'type' => ADUpdateRequest::DEACTIVATION_TYPE,
             'customer_id' => $event->customerId,
         ]);
+    }
+
+    public function onADUserEnabled(ADUserEnabled $event)
+    {
+        ADUpdateRequest::where('customer_id', $event->customerId)
+            ->where('type', CardUpdateRequest::ACTIVATION_TYPE)
+            ->delete();
+    }
+
+    public function onADUserDisabled(ADUserDisabled $event)
+    {
+        ADUpdateRequest::where('customer_id', $event->customerId)
+            ->where('type', CardUpdateRequest::DEACTIVATION_TYPE)
+            ->delete();
     }
 }

--- a/app/Reactors/ADUpdateRequestReactor.php
+++ b/app/Reactors/ADUpdateRequestReactor.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Reactors;
+
+use App\ADUpdateRequest;
+use App\StorableEvents\ADUserToBeDisabled;
+use App\StorableEvents\ADUserToBeEnabled;
+use Spatie\EventSourcing\EventHandlers\EventHandler;
+use Spatie\EventSourcing\EventHandlers\HandlesEvents;
+
+class ADUpdateRequestReactor implements EventHandler
+{
+    use HandlesEvents;
+
+    public function onADUserToBeEnabled(ADUserToBeEnabled $event)
+    {
+        ADUpdateRequest::create([
+            'type' => ADUpdateRequest::ACTIVATION_TYPE,
+            'customer_id' => $event->customerId,
+        ]);
+    }
+
+    public function onADUserToBeDisabled(ADUserToBeDisabled $event)
+    {
+        ADUpdateRequest::create([
+            'type' => ADUpdateRequest::DEACTIVATION_TYPE,
+            'customer_id' => $event->customerId,
+        ]);
+    }
+}

--- a/app/StorableEvents/ADUserDisabled.php
+++ b/app/StorableEvents/ADUserDisabled.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\StorableEvents;
+
+use Spatie\EventSourcing\ShouldBeStored;
+
+class ADUserDisabled implements ShouldBeStored
+{
+    public $customerId;
+
+    public function __construct($customerId)
+    {
+        $this->customerId = $customerId;
+    }
+}

--- a/app/StorableEvents/ADUserEnabled.php
+++ b/app/StorableEvents/ADUserEnabled.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\StorableEvents;
+
+use Spatie\EventSourcing\ShouldBeStored;
+
+class ADUserEnabled implements ShouldBeStored
+{
+    public $customerId;
+
+    public function __construct($customerId)
+    {
+        $this->customerId = $customerId;
+    }
+}

--- a/app/StorableEvents/ADUserToBeDisabled.php
+++ b/app/StorableEvents/ADUserToBeDisabled.php
@@ -6,7 +6,7 @@ use Spatie\EventSourcing\ShouldBeStored;
 
 class ADUserToBeDisabled implements ShouldBeStored
 {
-    private $customerId;
+    public $customerId;
 
     public function __construct($customerId)
     {

--- a/app/StorableEvents/ADUserToBeDisabled.php
+++ b/app/StorableEvents/ADUserToBeDisabled.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\StorableEvents;
+
+use Spatie\EventSourcing\ShouldBeStored;
+
+class ADUserToBeDisabled implements ShouldBeStored
+{
+    private $customerId;
+
+    public function __construct($customerId)
+    {
+        $this->customerId = $customerId;
+    }
+}

--- a/app/StorableEvents/ADUserToBeEnabled.php
+++ b/app/StorableEvents/ADUserToBeEnabled.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\StorableEvents;
+
+use Spatie\EventSourcing\ShouldBeStored;
+
+class ADUserToBeEnabled implements ShouldBeStored
+{
+    private $customerId;
+
+    public function __construct($customerId)
+    {
+        $this->customerId = $customerId;
+    }
+}

--- a/app/StorableEvents/ADUserToBeEnabled.php
+++ b/app/StorableEvents/ADUserToBeEnabled.php
@@ -6,7 +6,7 @@ use Spatie\EventSourcing\ShouldBeStored;
 
 class ADUserToBeEnabled implements ShouldBeStored
 {
-    private $customerId;
+    public $customerId;
 
     public function __construct($customerId)
     {

--- a/database/migrations/2020_12_10_034026_create_ad_update_requests_table.php
+++ b/database/migrations/2020_12_10_034026_create_ad_update_requests_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateADUpdateRequestsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('ad_update_requests', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+
+            $table->string('type');
+            $table->string('customer_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('ad_update_requests');
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\ADUpdateRequestsController;
 use App\Http\Controllers\CardUpdateRequestsController;
 use App\Http\Controllers\CardScannedController;
 use Illuminate\Support\Facades\Route;
@@ -24,3 +25,5 @@ Route::post("/active_card_holders", [CardUpdateRequestsController::class, "updat
 
 Route::post("/events/card_scanned", 'CardScannedController')
     ->middleware("auth:api");
+
+Route::get("/ad_updates", [ADUpdateRequestsController::class, "index"]);

--- a/routes/api.php
+++ b/routes/api.php
@@ -26,4 +26,7 @@ Route::post("/active_card_holders", [CardUpdateRequestsController::class, "updat
 Route::post("/events/card_scanned", 'CardScannedController')
     ->middleware("auth:api");
 
-Route::get("/ad_updates", [ADUpdateRequestsController::class, "index"]);
+Route::get("/ad_updates", [ADUpdateRequestsController::class, "index"])
+    ->middleware("auth:api");
+Route::post("/card_updates/{ad_update_request}/status", [ADUpdateRequestsController::class, "updateStatus"])
+    ->middleware("auth:api");

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,7 +2,6 @@
 
 use App\Http\Controllers\ADUpdateRequestsController;
 use App\Http\Controllers\CardUpdateRequestsController;
-use App\Http\Controllers\CardScannedController;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -16,17 +15,15 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-Route::get("/card_updates", [CardUpdateRequestsController::class, "index"])
-    ->middleware("auth:api");
-Route::post("/card_updates/{card_update_request}/status", [CardUpdateRequestsController::class, "updateStatus"])
-    ->middleware("auth:api");
-Route::post("/active_card_holders", [CardUpdateRequestsController::class, "updateActiveCardHolders"])
-    ->middleware("auth:api");
+Route::middleware(["auth:api"])
+    ->group(function () {
+        Route::get("/card_updates", [CardUpdateRequestsController::class, "index"]);
+        Route::post("/card_updates/{card_update_request}/status", [CardUpdateRequestsController::class, "updateStatus"]);
+        Route::post("/active_card_holders", [CardUpdateRequestsController::class, "updateActiveCardHolders"]);
 
-Route::post("/events/card_scanned", 'CardScannedController')
-    ->middleware("auth:api");
+        Route::post("/events/card_scanned", 'CardScannedController');
 
-Route::get("/ad_updates", [ADUpdateRequestsController::class, "index"])
-    ->middleware("auth:api");
-Route::post("/card_updates/{ad_update_request}/status", [ADUpdateRequestsController::class, "updateStatus"])
-    ->middleware("auth:api");
+        Route::get("/ad_updates", [ADUpdateRequestsController::class, "index"]);
+        Route::post("/card_updates/{ad_update_request}/status", [ADUpdateRequestsController::class, "updateStatus"]);
+    });
+

--- a/tests/Feature/App/Http/Controllers/ADUpdateRequestsControllerTest.php
+++ b/tests/Feature/App/Http/Controllers/ADUpdateRequestsControllerTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Feature\App\Http\Controllers;
+
+use App\ADUpdateRequest;
+use App\Customer;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class ADUpdateRequestsControllerTest extends TestCase
+{
+    use WithFaker;
+
+    /** @test */
+    public function can_retrieve_list_of_ad_updates()
+    {
+        /** @var Customer $customer */
+        $customer = Customer::create([
+            'first_name' => $this->faker->firstName,
+            'last_name' => $this->faker->lastName,
+            'username' => $this->faker->userName,
+            'email' => $this->faker->email,
+            'woo_id' => 1,
+            'member' => true,
+        ]);
+
+        /** @var ADUpdateRequest $enableRequest */
+        $enableRequest = ADUpdateRequest::create([
+            'type' => ADUpdateRequest::ACTIVATION_TYPE,
+            'customer_id' => $customer->id,
+        ]);
+
+        /** @var ADUpdateRequest $disableRequest */
+        $disableRequest = ADUpdateRequest::create([
+            'type' => ADUpdateRequest::DEACTIVATION_TYPE,
+            'customer_id' => $customer->id,
+        ]);
+
+        $response = $this->get('/api/ad_updates');
+        $response->assertJson([
+            'data' => [
+                [
+                    'id' => $enableRequest->id,
+                    'method' => ADUpdateRequest::ACTIVATION_TYPE,
+                    'username' => $customer->username,
+                    'first_name' => $customer->first_name,
+                    'last_name' => $customer->last_name
+                ],
+                [
+                    'id' => $disableRequest->id,
+                    'method' => ADUpdateRequest::DEACTIVATION_TYPE,
+                    'username' => $customer->username,
+                ],
+            ]
+        ]);
+    }
+}

--- a/tests/Feature/App/Http/Controllers/ADUpdateRequestsControllerTest.php
+++ b/tests/Feature/App/Http/Controllers/ADUpdateRequestsControllerTest.php
@@ -4,7 +4,6 @@ namespace Tests\Feature\App\Http\Controllers;
 
 use App\ADUpdateRequest;
 use App\Customer;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 

--- a/tests/Unit/Aggregates/MembershipAggregate/AccessCardTest.php
+++ b/tests/Unit/Aggregates/MembershipAggregate/AccessCardTest.php
@@ -5,6 +5,8 @@ namespace Tests\Unit\Aggregates\MembershipAggregate;
 
 use App\Aggregates\MembershipAggregate;
 use App\CardUpdateRequest;
+use App\StorableEvents\ADUserToBeDisabled;
+use App\StorableEvents\ADUserToBeEnabled;
 use App\StorableEvents\CardActivated;
 use App\StorableEvents\CardAdded;
 use App\StorableEvents\CardDeactivated;
@@ -17,7 +19,6 @@ use App\StorableEvents\CustomerUpdated;
 use App\StorableEvents\MembershipActivated;
 use App\StorableEvents\MembershipDeactivated;
 use App\StorableEvents\SubscriptionCreated;
-use App\StorableEvents\SubscriptionImported;
 use App\StorableEvents\SubscriptionUpdated;
 use Illuminate\Support\Facades\Event;
 use Spatie\EventSourcing\Facades\Projectionist;
@@ -51,6 +52,7 @@ class AccessCardTest extends TestCase
                 new SubscriptionUpdated($subscription),
                 new MembershipActivated($customer->id),
                 new CardSentForActivation($customer->id, $card),
+                new ADUserToBeEnabled($customer->id),
             ]);
     }
 
@@ -136,6 +138,7 @@ class AccessCardTest extends TestCase
                 new MembershipDeactivated($customer->id),
                 new CardSentForDeactivation($customer->id, '42424'),
                 new CardSentForDeactivation($customer->id, '53535'),
+                new ADUserToBeDisabled($customer->id),
             ]);
     }
 
@@ -257,6 +260,7 @@ class AccessCardTest extends TestCase
                 new SubscriptionUpdated($subscription),
                 new MembershipActivated($customer->id),
                 new CardSentForActivation($customer->id, $card),
+                new ADUserToBeEnabled($customer->id),
             ]);
     }
 

--- a/tests/Unit/Aggregates/MembershipAggregate/ActiveDirectoryTest.php
+++ b/tests/Unit/Aggregates/MembershipAggregate/ActiveDirectoryTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Unit\Aggregates\MembershipAggregate;
+
+
+use App\Aggregates\MembershipAggregate;
+use App\StorableEvents\ADUserToBeDisabled;
+use App\StorableEvents\ADUserToBeEnabled;
+use App\StorableEvents\CustomerCreated;
+use App\StorableEvents\MembershipActivated;
+use App\StorableEvents\MembershipDeactivated;
+use App\StorableEvents\SubscriptionUpdated;
+use Illuminate\Support\Facades\Event;
+use Spatie\EventSourcing\Facades\Projectionist;
+use Tests\TestCase;
+
+class ActiveDirectoryTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Event::fake();
+        Projectionist::withoutEventHandlers();
+    }
+
+    /** @test */
+    public function ad_is_ready_to_enable_when_membership_is_activated()
+    {
+        $customer = $this->customer();
+        $subscription = $this->subscription()->status('active');
+
+        MembershipAggregate::fakeCustomer($customer)
+            ->given([
+                new CustomerCreated($customer),
+                new SubscriptionUpdated($this->subscription()->status('need-id-check')),
+            ])
+            ->updateSubscription($subscription)
+            ->assertRecorded([
+                new SubscriptionUpdated($subscription),
+                new MembershipActivated($customer->id),
+                new ADUserToBeEnabled($customer->id),
+            ]);
+    }
+
+    /** @test */
+    public function ad_is_ready_to_disable_when_membership_is_deactivated()
+    {
+        $customer = $this->customer();
+        $cancelledSubscription = $this->subscription()->status('cancelled');
+
+        MembershipAggregate::fakeCustomer($customer)
+            ->given([
+                new CustomerCreated($customer),
+                new SubscriptionUpdated($this->subscription()->status('active')),
+            ])
+            ->updateSubscription($cancelledSubscription)
+            ->assertRecorded([
+                new SubscriptionUpdated($cancelledSubscription),
+                new MembershipDeactivated($customer->id),
+                new ADUserToBeDisabled($customer->id),
+            ]);
+    }
+}

--- a/tests/Unit/Aggregates/MembershipAggregate/ActiveMembershipTest.php
+++ b/tests/Unit/Aggregates/MembershipAggregate/ActiveMembershipTest.php
@@ -4,6 +4,8 @@ namespace Tests\Unit\Aggregates\MembershipAggregate;
 
 
 use App\Aggregates\MembershipAggregate;
+use App\StorableEvents\ADUserToBeDisabled;
+use App\StorableEvents\ADUserToBeEnabled;
 use App\StorableEvents\CustomerCreated;
 use App\StorableEvents\MembershipActivated;
 use App\StorableEvents\MembershipDeactivated;
@@ -39,6 +41,7 @@ class ActiveMembershipTest extends TestCase
             ->assertRecorded([
                 new SubscriptionUpdated($newSubscription),
                 new MembershipActivated($customer->id),
+                new ADUserToBeEnabled($customer->id),
             ]);
     }
 
@@ -58,6 +61,7 @@ class ActiveMembershipTest extends TestCase
             ->assertRecorded([
                 new SubscriptionUpdated($newSubscription),
                 new MembershipActivated($customer->id),
+                new ADUserToBeEnabled($customer->id),
             ]);
     }
 
@@ -76,6 +80,7 @@ class ActiveMembershipTest extends TestCase
             ->assertRecorded([
                 new SubscriptionUpdated($newSubscription),
                 new MembershipActivated($customer->id),
+                new ADUserToBeEnabled($customer->id),
             ]);
     }
 
@@ -95,6 +100,7 @@ class ActiveMembershipTest extends TestCase
             ->assertRecorded([
                 new SubscriptionUpdated($newSubscription),
                 new MembershipDeactivated($customer->id),
+                new ADUserToBeDisabled($customer->id),
             ]);
     }
 
@@ -114,6 +120,7 @@ class ActiveMembershipTest extends TestCase
             ->assertRecorded([
                 new SubscriptionUpdated($newSubscription),
                 new MembershipDeactivated($customer->id),
+                new ADUserToBeDisabled($customer->id),
             ]);
     }
 
@@ -133,6 +140,7 @@ class ActiveMembershipTest extends TestCase
             ->assertRecorded([
                 new SubscriptionUpdated($newSubscription),
                 new MembershipDeactivated($customer->id),
+                new ADUserToBeDisabled($customer->id),
             ]);
     }
 

--- a/tests/Unit/Aggregates/MembershipAggregate/NoEventUserTest.php
+++ b/tests/Unit/Aggregates/MembershipAggregate/NoEventUserTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\Aggregates\MembershipAggregate;
 
 
+use App\ADUpdateRequest;
 use App\Aggregates\MembershipAggregate;
 use App\CardUpdateRequest;
 use App\StorableEvents\CustomerIsNoEventTestUser;
@@ -111,6 +112,22 @@ class NoEventUserTest extends TestCase
         MembershipAggregate::fakeCustomer($customer->id)
             ->given(new CustomerIsNoEventTestUser($customer->id))
             ->updateCardStatus($cardUpdateRequest, CardUpdateRequest::STATUS_SUCCESS)
+            ->assertNothingRecorded();
+    }
+
+    /** @test */
+    public function ad_update_request_does_not_make_event()
+    {
+        $customer = $this->customer();
+
+        $adUpdateRequest = ADUpdateRequest::create([
+            'customer_id' => $customer->id,
+            'type' => CardUpdateRequest::ACTIVATION_TYPE,
+        ]);
+
+        MembershipAggregate::fakeCustomer($customer->id)
+            ->given(new CustomerIsNoEventTestUser($customer->id))
+            ->updateADStatus($adUpdateRequest, ADUpdateRequest::STATUS_SUCCESS)
             ->assertNothingRecorded();
     }
 }

--- a/tests/Unit/Reactors/ADUpdateRequestReactorTest.php
+++ b/tests/Unit/Reactors/ADUpdateRequestReactorTest.php
@@ -5,6 +5,8 @@ namespace Tests\Unit\Reactors;
 
 use App\ADUpdateRequest;
 use App\Reactors\ADUpdateRequestReactor;
+use App\StorableEvents\ADUserDisabled;
+use App\StorableEvents\ADUserEnabled;
 use App\StorableEvents\ADUserToBeDisabled;
 use App\StorableEvents\ADUserToBeEnabled;
 use Tests\TestCase;
@@ -44,5 +46,81 @@ class ADUpdateRequestReactorTest extends TestCase
 
         $this->assertNotNull($model);
         $this->assertEquals(ADUpdateRequest::DEACTIVATION_TYPE, $model->type);
+    }
+
+    /** @test */
+    public function ad_user_enabled_deletes_activation_update_request()
+    {
+        $customerId = 1;
+        ADUpdateRequest::create([
+            'type' => ADUpdateRequest::ACTIVATION_TYPE,
+            'customer_id' => $customerId,
+        ]);
+
+        $event = new ADUserEnabled($customerId);
+
+        event($event);
+
+        /** @var ADUpdateRequest $model */
+        $model = ADUpdateRequest::where('customer_id', $event->customerId)->first();
+
+        $this->assertNull($model);
+    }
+
+    /** @test */
+    public function ad_user_disabled_deletes_deactivation_update_request()
+    {
+        $customerId = 1;
+        ADUpdateRequest::create([
+            'type' => ADUpdateRequest::DEACTIVATION_TYPE,
+            'customer_id' => $customerId,
+        ]);
+
+        $event = new ADUserDisabled($customerId);
+
+        event($event);
+
+        /** @var ADUpdateRequest $model */
+        $model = ADUpdateRequest::where('customer_id', $event->customerId)->first();
+
+        $this->assertNull($model);
+    }
+
+    /** @test */
+    public function ad_user_enabled_does_not_delete_deactivation_update_request()
+    {
+        $customerId = 1;
+        ADUpdateRequest::create([
+            'type' => ADUpdateRequest::DEACTIVATION_TYPE,
+            'customer_id' => $customerId,
+        ]);
+
+        $event = new ADUserEnabled($customerId);
+
+        event($event);
+
+        /** @var ADUpdateRequest $model */
+        $model = ADUpdateRequest::where('customer_id', $event->customerId)->first();
+
+        $this->assertNotNull($model);
+    }
+
+    /** @test */
+    public function ad_user_disabled_does_not_delete_activation_update_request()
+    {
+        $customerId = 1;
+        ADUpdateRequest::create([
+            'type' => ADUpdateRequest::ACTIVATION_TYPE,
+            'customer_id' => $customerId,
+        ]);
+
+        $event = new ADUserDisabled($customerId);
+
+        event($event);
+
+        /** @var ADUpdateRequest $model */
+        $model = ADUpdateRequest::where('customer_id', $event->customerId)->first();
+
+        $this->assertNotNull($model);
     }
 }

--- a/tests/Unit/Reactors/ADUpdateRequestReactorTest.php
+++ b/tests/Unit/Reactors/ADUpdateRequestReactorTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Unit\Reactors;
+
+
+use App\ADUpdateRequest;
+use App\Reactors\ADUpdateRequestReactor;
+use App\StorableEvents\ADUserToBeDisabled;
+use App\StorableEvents\ADUserToBeEnabled;
+use Tests\TestCase;
+
+class ADUpdateRequestReactorTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->withOnlyEventHandler(ADUpdateRequestReactor::class);
+    }
+
+    /** @test */
+    public function ad_user_to_be_enabled_creates_update_request()
+    {
+        $event = new ADUserToBeEnabled(1);
+
+        event($event);
+
+        /** @var ADUpdateRequest $model */
+        $model = ADUpdateRequest::where('customer_id', $event->customerId)->first();
+
+        $this->assertNotNull($model);
+        $this->assertEquals(ADUpdateRequest::ACTIVATION_TYPE, $model->type);
+    }
+
+    /** @test */
+    public function ad_user_to_be_disabled_creates_update_request()
+    {
+        $event = new ADUserToBeDisabled(1);
+
+        event($event);
+
+        /** @var ADUpdateRequest $model */
+        $model = ADUpdateRequest::where('customer_id', $event->customerId)->first();
+
+        $this->assertNotNull($model);
+        $this->assertEquals(ADUpdateRequest::DEACTIVATION_TYPE, $model->type);
+    }
+}


### PR DESCRIPTION
We set up an active directory server, but it needs to be able to pull in account updates when someone becomes a member or stops being a member. This code handles all of that on the webhooks side. It's based on the code used for card access updates.