### PR TITLE
change equipment auth menu order for UX bug workaround

### DIFF
--- a/app/Slack/Modals/EquipmentAuthorization.php
+++ b/app/Slack/Modals/EquipmentAuthorization.php
@@ -44,6 +44,16 @@ class EquipmentAuthorization implements ModalInterface
 
         $this->modalView->newInput()
             ->dispatchAction()
+            ->blockId(self::PERSON_DROPDOWN)
+            ->label("Person")
+            ->newSelectMenu()
+            ->forExternalOptions()
+            ->actionId(self::PERSON_DROPDOWN)
+            ->placeholder("Select a member")
+            ->minQueryLength(2);
+
+        $this->modalView->newInput()
+            ->dispatchAction()
             ->blockId(self::EQUIPMENT_DROPDOWN)
             ->label("Equipment")
             ->newSelectMenu()
@@ -52,15 +62,6 @@ class EquipmentAuthorization implements ModalInterface
             ->placeholder("Select equipment")
             ->minQueryLength(0);
 
-        $this->modalView->newInput()
-            ->dispatchAction()
-            ->blockId(self::PERSON_DROPDOWN)
-            ->label("Person")
-            ->newSelectMenu()
-            ->forExternalOptions()
-            ->actionId(self::PERSON_DROPDOWN)
-            ->placeholder("Select a member")
-            ->minQueryLength(2);
     }
 
     public static function callbackId(): string


### PR DESCRIPTION
UX workaround to address a bug where sometimes the user vs trainer checkboxes don't appear when running /membership > equipment authorization. This bug seems to only happen when the the equipment is selected first and then the person. This PR changes the order of the member and equipment dropdowns and provides UX suggestion that user should select person first before equipment. 

I don't have a test environment setup and have not verified this change actually reorders the dropdowns. Possibly needs code lines in getBlockActions() reordered too?

state where both dropdowns have been selected but user vs trainer checkboxes don't appear.
![image](https://user-images.githubusercontent.com/4761714/218291315-50a29c47-815d-4a1e-bdfb-364e46cb4e55.png)
![image](https://user-images.githubusercontent.com/4761714/218291319-d79bfa48-3cb1-4d6f-8410-dedf3bea1706.png)
