### PR TITLE
[Slack] Refactor EquipmentAuthorizationModal to support authorizing multiple people and equipment

### DIFF
--- a/app/External/Slack/Api/ViewsApi.php
+++ b/app/External/Slack/Api/ViewsApi.php
@@ -53,8 +53,5 @@ class ViewsApi
             ->post('https://denhac.slack.com/api/views.update', [
                 RequestOptions::JSON => $data,
             ]);
-
-        Log::info('Slack Views Publish');
-        Log::info(json_decode($response->getBody(), true));
     }
 }

--- a/app/External/Slack/Modals/CountdownTestModal.php
+++ b/app/External/Slack/Modals/CountdownTestModal.php
@@ -77,7 +77,6 @@ class CountdownTestModal implements ModalInterface
 
     public static function onBlockAction(SlackRequest $request)
     {
-        Log::info(print_r($request->payload(), true));
         $viewId = $request->payload()['view']['id'];
         app(CountdownModalLoop::class)
             ->onQueue()

--- a/app/External/Slack/Modals/CreateTrainableEquipment.php
+++ b/app/External/Slack/Modals/CreateTrainableEquipment.php
@@ -109,8 +109,6 @@ class CreateTrainableEquipment implements ModalInterface
 
     public static function handle(SlackRequest $request)
     {
-        Log::info('Create Trainable Equipment');
-        Log::info(print_r($request->payload(), true));
         $values = $request->payload()['view']['state']['values'];
 
         $equipmentName = $values[self::EQUIPMENT_NAME][self::EQUIPMENT_NAME]['value'];

--- a/app/External/Slack/Modals/EquipmentAuthorization.php
+++ b/app/External/Slack/Modals/EquipmentAuthorization.php
@@ -133,14 +133,14 @@ class EquipmentAuthorization implements ModalInterface
         ];
     }
 
-    public static function equipmentFromState($state)
+    public static function equipmentFromState($state): Collection
     {
         return collect($state[self::EQUIPMENT_DROPDOWN][self::EQUIPMENT_DROPDOWN] ?? [])
             -> map(fn($formValue) => str_replace('equipment-', '', $formValue))
             -> map(fn($equipmentId) => TrainableEquipment::find($equipmentId));
     }
 
-    public static function peopleFromState($state)
+    public static function peopleFromState($state): Collection
     {
         return collect($state[self::PERSON_DROPDOWN][self::PERSON_DROPDOWN] ?? [])
             -> map(fn($formValue) => str_replace('customer-', '', $formValue))
@@ -192,6 +192,7 @@ class EquipmentAuthorization implements ModalInterface
         }
         
         if (! empty($selectedEquipment) && ! empty($selectedMembers)) {
+            // Render information about any selected people who have existing permisisons for this equipment.
 
             $alreadyTrained = [];
             $alreadyTrainers = [];

--- a/app/External/Slack/Modals/ModalTrait.php
+++ b/app/External/Slack/Modals/ModalTrait.php
@@ -110,6 +110,12 @@ trait ModalTrait
                     foreach ($selectedOptions as $option) {
                         $result[$blockId][$actionId][] = $option['value'];
                     }
+                } elseif ($actionValues['type'] == 'multi_external_select') {
+                    $selected = [];
+                    foreach ($actionValues['selected_options'] as $selectedOption) {
+                        $selected[] = $selectedOption['value'] ;
+                    }
+                    $result[$blockId][$actionId] = $selected;
                 } elseif (array_key_exists('selected_option', $actionValues)) {
                     $selected = $actionValues['selected_option'];
                     if (empty($selected)) {

--- a/app/Http/Controllers/SlackInteractivityController.php
+++ b/app/Http/Controllers/SlackInteractivityController.php
@@ -63,15 +63,11 @@ class SlackInteractivityController extends Controller
 
     private function blockAction(SlackRequest $request)
     {
-        Log::info('Block Action!');
-        Log::info(print_r($request->payload(), true));
-
         $payload = $request->payload();
         $actions = $payload['actions'];
 
         // If we're a modal, try to find a block action on the modal
         if (array_key_exists('view', $payload) && $payload['view']['type'] == 'modal') {
-            Log::info('View is a modal!');
             $view = $request->payload()['view'];
             $callbackId = $view['callback_id'];
 

--- a/app/Http/Controllers/SlackOptionsController.php
+++ b/app/Http/Controllers/SlackOptionsController.php
@@ -10,9 +10,6 @@ class SlackOptionsController extends Controller
 {
     public function __invoke(SlackRequest $request)
     {
-        //        Log::info("Options request!");
-        //        Log::info(print_r($request->payload(), true));
-
         $payload = $request->payload();
 
         if ($payload['type'] == 'block_suggestion') {


### PR DESCRIPTION
# Overview
This PR modifies the `EquipmentAuthorization` modal within the `/membership` command.
It makes it possible to submit authorizations for multiple people and multiple pieces of equipment with a single form submission. This greatly reduces the amount of time it takes trainers to enter authorizations, which is currently a pain point for trainers running large classes - especially for the woodshop which typically trains on four pieces of equipment at once.

## Before/After:
![Equipment Authorization BeforeAfter](https://github.com/Denhac/denhac-webhooks/assets/22403528/98be30ff-bfd3-4b66-9cf2-202f56b1dc92)


# Changes
This feature requires two sets of changes:
## Using Multiselect
The primary change is to switch the member and equipment selects to be multi-select inputs.
This required an update to `ModalTrait::getStateValues` to add support for `type=multi_external_select`.
In `EquipmentAuthorization::handle`, we now iterate over people and equipment to call `addMembership` as many times as necessary.

## Decoupling Checkboxes from User State
Previously, when a user and piece of equipment was selected, `EquipmentAuthorization::onBlockAction` would update the form to show checkboxes for user and trainer permissions, or messages that stated that the user already had these permissions - depending on the user's state. In order to maintain full granularity of these permissions, we would have needed a table with two checkboxes per user. This seemed unnecessarily complicated to implement and too cluttered for how people tend to use this form.

I made the following decisions:
* I decided to keep a single "trainer" checkbox that applies to all selected  users
* I replaced the "user" checkbox with a static message indicating that all members will be made users. 
* I added an "information" section that lists any pre-existing conditions. We will skip pre-existing permissions when submitting the form.
  * The information section is not visible if all members are new to all of the selected equipment:
![Screenshot 2024-01-07 at 5 47 02 PM](https://github.com/Denhac/denhac-webhooks/assets/22403528/7d82fdff-e4cb-4932-ba82-d48ec377662a)

# Testing
I have tested this change locally by merging it with my [docker dev branch](https://github.com/Denhac/denhac-webhooks/compare/main...ch-docker-dev). While still in-progress, it's functional enough to be able to to run this slack command. It currently requires manually seeding the database with at least two users, connecting one of them to your slack id, and either manually manually giving yourself the meta trainer permission or bypassing those permission checks in the [MembershipOptionsModal](https://github.com/Denhac/denhac-webhooks/blob/6b54492918a2e42b935983ec64e151548522717b/app/External/Slack/Modals/MembershipOptionsModal.php#L138C22-L138C23)
I haven't yet explored unit testing this feature.

Below are the log outputs for the dev stack that were generated from the submission in the "After" photo:
![Screenshot 2024-01-07 at 4 37 42 PM](https://github.com/Denhac/denhac-webhooks/assets/22403528/5245d0e4-14c2-4bf1-8395-a648d9e32390)

`TrainableEquipment`:
![Screenshot 2024-01-07 at 6 14 32 PM](https://github.com/Denhac/denhac-webhooks/assets/22403528/f3a1b559-1970-40df-b371-de24bb0f1671)

The trainer (Fizz Buzz, User 1) is already a trainer on all three pieces of equipment, and a user on two (unrealistic, but useful for testing). They already have five of six possible memberships. User 2, Buzz Lightyear, is not a user or trainer on any of the equipment, and so needs all six possible memberships.
We correctly see the following relations posted to "denhac.org":
* User 1 Plan 5 (User: Router Table)
* User 2 Plan 0 (Trainer: Table Saw)
* User 2 Plan 1 (User: Table Saw)
* User 2 Plan 2 (Trainer: Jointer)
* User 2 Plan 3 (User: Jointer)
* User 2 Plan 4 (Trainer: Router Table)
* User 2 Plan 5 (User: Router Table)

![Screenshot 2024-01-07 at 5 02 02 PM](https://github.com/Denhac/denhac-webhooks/assets/22403528/ecd9ab6c-5027-402b-81c9-f1f26fcbc4bc)


# Potential Further Improvements
### maps for code reuse and readability
There are four loops that that iterate over the multiselect values, eg [`foreach($personValues as $personValue) {`](https://github.com/Denhac/denhac-webhooks/compare/ch-membership-equipment-multi-authorize?expand=1#diff-bcfcb863ab204520a7ee541411c7bbd1b119648423d60e23f7d951b92a2fa0afR103). 
I'd have rather made `private static function personFromValue($personValue)` and used it as `$allPeople = array_map(self::$personFromValue, $personValues)`, however I'm new to php and couldn't get the syntax right.

### Submit modal should have the option to authorize more
Given that the trainer checkbox applies to all users, it would be nice if the success modal gave you the option to go back to the form and submit another batch. This could also be useful if some people didn't receive training for all equipment. It's just faster than rerunning the whole slash command. In fact, if such a button existed it may enough to alleviate much of the need for this PR. 

### Preload some options
The membership command has a few select fields that don't need to be loaded asynchronously. When we launch the membership modal, we already know who you are and what permissions you have. We should use a static select there. We can also do this for the equipment list, as it's a small list and is very unlikely to change while you have the modal open.

### Autoselect single option
For many of our users, the only command available in the membership command is the training item. Similarly, they may only be a trainer for one piece of equipment. In these cases, it would be ideal to skip the "what would you like to do?" page and preselect the only available piece of equipment.
