### PR TITLE
Fixes #46: Handling Slack rate limits for queued actions a little better

### DIFF
--- a/app/Actions/Slack/AddToUserGroup.php
+++ b/app/Actions/Slack/AddToUserGroup.php
@@ -4,6 +4,7 @@ namespace App\Actions\Slack;
 
 use App\Actions\StaticAction;
 use App\External\Slack\SlackApi;
+use App\External\Slack\SlackRateLimit;
 use Spatie\QueueableAction\QueueableAction;
 
 class AddToUserGroup
@@ -11,6 +12,8 @@ class AddToUserGroup
     use QueueableAction;
     use StaticAction;
     use SlackActionTrait;
+
+    public string $queue = 'slack-rate-limited';
 
     private SlackApi $slackApi;
 
@@ -34,5 +37,13 @@ class AddToUserGroup
         $users->add($slackId);
 
         $this->slackApi->usergroups->users->update($id, $users);
+    }
+
+    public function middleware()
+    {
+        return [
+            SlackRateLimit::usergroups_list(),
+            SlackRateLimit::usergroups_update(),
+        ];
     }
 }

--- a/app/Actions/Slack/RemoveFromChannel.php
+++ b/app/Actions/Slack/RemoveFromChannel.php
@@ -4,6 +4,7 @@ namespace App\Actions\Slack;
 
 use App\Actions\StaticAction;
 use App\External\Slack\SlackApi;
+use App\External\Slack\SlackRateLimit;
 use Spatie\QueueableAction\QueueableAction;
 
 class RemoveFromChannel
@@ -11,6 +12,8 @@ class RemoveFromChannel
     use QueueableAction;
     use StaticAction;
     use SlackActionTrait;
+
+    public string $queue = 'slack-rate-limited';
 
     private SlackApi $slackApi;
 
@@ -33,5 +36,13 @@ class RemoveFromChannel
         }
 
         throw new \Exception("Kick of $userId from $channel failed: ".print_r($response, true));
+    }
+
+    public function middleware()
+    {
+        return [
+            SlackRateLimit::conversations_list(),
+            SlackRateLimit::conversations_kick(),
+        ];
     }
 }

--- a/app/Actions/Slack/RemoveFromUserGroup.php
+++ b/app/Actions/Slack/RemoveFromUserGroup.php
@@ -4,6 +4,7 @@ namespace App\Actions\Slack;
 
 use App\Actions\StaticAction;
 use App\External\Slack\SlackApi;
+use App\External\Slack\SlackRateLimit;
 use Spatie\QueueableAction\QueueableAction;
 
 class RemoveFromUserGroup
@@ -11,6 +12,8 @@ class RemoveFromUserGroup
     use QueueableAction;
     use StaticAction;
     use SlackActionTrait;
+
+    public string $queue = 'slack-rate-limited';
 
     private SlackApi $slackApi;
 
@@ -36,5 +39,13 @@ class RemoveFromUserGroup
             });
 
         $this->slackApi->usergroups->users->update($id, $users);
+    }
+
+    public function middleware()
+    {
+        return [
+            SlackRateLimit::usergroups_list(),
+            SlackRateLimit::usergroups_update(),
+        ];
     }
 }

--- a/app/Actions/Slack/SendMessage.php
+++ b/app/Actions/Slack/SendMessage.php
@@ -3,6 +3,7 @@
 namespace App\Actions\Slack;
 
 use App\External\Slack\SlackApi;
+use App\External\Slack\SlackRateLimit;
 use App\Models\Customer;
 use Illuminate\Support\Str;
 use SlackPhp\BlockKit\Surfaces\Message;
@@ -12,6 +13,8 @@ class SendMessage
 {
     use QueueableAction;
     use SlackActionTrait;
+
+    public string $queue = 'slack-rate-limited';
 
     private SlackApi $api;
 
@@ -37,5 +40,12 @@ class SendMessage
         // At this point, userId should be just a string of the slack id that we care about
 
         $this->api->chat->postMessage($userId, $message);
+    }
+
+    public function middleware()
+    {
+        return [
+            SlackRateLimit::chat_postMessage(),
+        ];
     }
 }

--- a/app/Actions/Slack/UpdateSlackUserProfile.php
+++ b/app/Actions/Slack/UpdateSlackUserProfile.php
@@ -4,6 +4,7 @@ namespace App\Actions\Slack;
 
 use App\Actions\StaticAction;
 use App\External\Slack\SlackApi;
+use App\External\Slack\SlackRateLimit;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
@@ -15,6 +16,8 @@ class UpdateSlackUserProfile
 
     use QueueableAction;
     use StaticAction;
+
+    public string $queue = 'slack-rate-limited';
 
     private SlackApi $slackApi;
 
@@ -28,7 +31,7 @@ class UpdateSlackUserProfile
      */
     public function execute(string $slackId, array $fields)
     {
-        $updateTimeCacheKey = self::LAST_UPDATE_TIME_CACHE_KEY_PREFIX.$slackId;
+        $updateTimeCacheKey = self::LAST_UPDATE_TIME_CACHE_KEY_PREFIX . $slackId;
         if (Cache::has($updateTimeCacheKey)) {
             $lastUpdateTime = Cache::get($updateTimeCacheKey);
             if ($lastUpdateTime >= Carbon::now()->subMinute()) {
@@ -37,11 +40,18 @@ class UpdateSlackUserProfile
         }
         Cache::forever($updateTimeCacheKey, Carbon::now());
 
-        Log::info("Updating fields for {$slackId}: ".print_r($fields, true));
+        Log::info("Updating fields for {$slackId}: " . print_r($fields, true));
         $response = $this->slackApi->users->profile->set($slackId, [
             'fields' => $fields,
         ]);
         Log::info("Response status: {$response->getStatusCode()}");
         Log::info("Response body: {$response->getBody()->getContents()}");
+    }
+
+    public function middleware()
+    {
+        return [
+            SlackRateLimit::users_profile_set(),
+        ];
     }
 }

--- a/app/Actions/Slack/UpdateSpaceBotAppHome.php
+++ b/app/Actions/Slack/UpdateSpaceBotAppHome.php
@@ -15,6 +15,8 @@ class UpdateSpaceBotAppHome
     use QueueableAction;
     use StaticAction;
 
+    public string $queue = 'slack-rate-limited';
+
     private SlackApi $slackApi;
 
     private AppHome $home;

--- a/app/Actions/Slack/VerifySlackUserProfile.php
+++ b/app/Actions/Slack/VerifySlackUserProfile.php
@@ -4,7 +4,7 @@ namespace App\Actions\Slack;
 
 use App\External\Slack\SlackApi;
 use App\External\Slack\SlackProfileFields;
-use Illuminate\Queue\Middleware\RateLimited;
+use App\External\Slack\SlackRateLimit;
 use Spatie\QueueableAction\QueueableAction;
 
 /**
@@ -39,6 +39,8 @@ class VerifySlackUserProfile
 
     public function middleware()
     {
-        return [new RateLimited('slack-profile-update')];
+        return [
+            SlackRateLimit::users_profile_get(),
+        ];
     }
 }

--- a/app/External/Slack/SlackRateLimit.php
+++ b/app/External/Slack/SlackRateLimit.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\External\Slack;
+
+use App\Http\Middleware\SlackPostMessageRateLimit;
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Queue\Middleware\RateLimited;
+use Illuminate\Support\Facades\RateLimiter;
+
+/**
+ * @method static SlackPostMessageRateLimit chat_postMessage()
+ *
+ * @method static RateLimited conversations_invite()
+ * @method static RateLimited conversations_join()
+ * @method static RateLimited conversations_kick()
+ * @method static RateLimited conversations_list()
+ *
+ * @method static RateLimited usergroups_list()
+ * @method static RateLimited usergroups_update()
+ *
+ * @method static RateLimited users_profile_get()
+ * @method static RateLimited users_profile_set()
+ *
+ * @method static RateLimited views_publish()
+ */
+class SlackRateLimit
+{
+    protected const POSTING = 'posting';
+    protected const TIER_1 = 'tier-1';
+    protected const TIER_2 = 'tier-2';
+    protected const TIER_3 = 'tier-3';
+    protected const TIER_4 = 'tier-4';
+
+    protected static array $tierPerMinute = [
+        self::TIER_1 => 1,
+        self::TIER_2 => 20,
+        self::TIER_3 => 50,
+        self::TIER_4 => 100,
+    ];
+
+    protected static array $apiCall = [
+        'chat_postMessage' => self::POSTING,
+        'conversations_invite' => self::TIER_3,
+        'conversations_join' => self::TIER_3,
+        'conversations_kick' => self::TIER_3,
+        'conversations_list' => self::TIER_2,
+        'usergroups_list' => self::TIER_2,
+        'usergroups_update' => self::TIER_2,
+        'users_profile_get' => self::TIER_4,
+        'users_profile_set' => self::TIER_3,
+        'views_publish' => self::TIER_4,
+    ];
+
+    public static function __callStatic(string $name, array $arguments)
+    {
+        if (!array_key_exists($name, self::$apiCall)) {
+            throw new \Exception("Unknown api call $name");
+        }
+
+        $tier = self::$apiCall[$name];
+
+        if ($tier === self::POSTING) {
+            return app(SlackPostMessageRateLimit::class);
+        }
+
+        if (!array_key_exists($tier, self::$tierPerMinute)) {
+            throw new \Exception("Unknown tier level $tier for api method $name");
+        }
+
+        return self::limit($tier, $name);
+    }
+
+    private static function limit($tier, $name)
+    {
+        if (is_null($name)) {
+            $limit_key = "slack-$tier";
+        } else {
+            $limit_key = "slack-$tier-$name";
+        }
+        $limiter = RateLimiter::limiter($limit_key);
+
+        if (is_null($limiter)) {
+            RateLimiter::for($limit_key, function () use ($tier) {
+                return Limit::perMinute(self::$tierPerMinute[$tier]);
+            });
+        }
+
+        return new RateLimited($limit_key);
+    }
+}

--- a/app/Http/Middleware/SlackPostMessageRateLimit.php
+++ b/app/Http/Middleware/SlackPostMessageRateLimit.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Cache\Repository as Cache;
+use Illuminate\Queue\InteractsWithQueue;
+use Psr\SimpleCache\InvalidArgumentException;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * The normal rate limiting is on a per minute scale. Slack's post message limits are 1 per second. The cache can handle
+ * it but the API is somewhat limited. This class is based on \Illuminate\Queue\Middleware\RateLimited but we can
+ * simplify it a bit since we aren't trying to limit it by a specific name or handle multiple rate limits. We also
+ * assume there's no such thing as too many retries for posting a message. The queue will eventually clear or hit our
+ * max failures for the queue.
+ */
+class SlackPostMessageRateLimit
+{
+    private static string $cacheKey = "slack-post-message-rate-limit";
+    protected Cache $cache;
+
+    public function __construct(Cache $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    /**
+     * @param InteractsWithQueue $job
+     * @throws InvalidArgumentException
+     */
+    public function handle(mixed $job, Closure $next): Response
+    {
+        if($this->cache->has(self::$cacheKey)) {
+            $job->release(1);  // Try again in one second
+        }
+
+        $added = $this->cache->add(self::$cacheKey, 0, 1);
+        if(! $added) {
+            // Concurrent job must have added it and we were second. Relies on cache to handle race condition
+            $job->release(1);
+        }
+
+        return $next($job);
+    }
+
+    /**
+     * After deserialization, we need our cache again.
+     *
+     * @return void
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
+    public function __wakeup()
+    {
+        $this->cache = Container::getInstance()->make(Cache::class);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -46,12 +46,5 @@ class AppServiceProvider extends ServiceProvider
 
             return $dataService->getOAuth2LoginHelper();
         });
-
-        RateLimiter::for('slack-profile-update', function () {
-            // users.profile.set is tier 3, 50+ per minute.
-            // users.profile.get is tier 4, 100+ per minute.
-            // We probably won't update every user, but just to be on the safe side, we assume here that we do.
-            return Limit::perMinute(50);
-        });
     }
 }


### PR DESCRIPTION
I added rate limits to all of the Slack actions. The only one that got a little weird was chat.postMessage since the rate limiting API is calls per minute and postMessage is 1 per second. I made a `SlackPostMessageRateLimit` to work around that since the postMessage api calls are very weird in the first place. They have two limits built in, one that is overall per workspace and is just "several hundred messages per minute" and the other that is per channel which is one per second. Given our volume, I just made the assumption that one per second across our workspace is more than sufficient.

One thing I don't fully like is that the code for the RateLimited class increments the counter for number of attempts for each limit. If our first rate limit in our list is good to go, but the second isn't, the job will retry but it will retry after the rate limit for the second is ready to retry and it still counted against our rate limit for the first even though our api method wasn't called. I don't see a way around this without implementing our own middleware instead of the RateLimited one. I'm not sure it's worth the effort just yet as we're talking about an "a lot of stuff would have to go wrong for us to even notice this" type of issue.

The one benefit to that issue is if we call the same api method twice in our code, we just put the rate limit twice into the list. If we're right on the cusp of hitting our rate limit, the first entry may be fine but the second fails because we incremented our limit for the first one. Silver linings I guess. 