### PR TITLE
[Slack][Equipment Authorization] Remove redundant empty form information

### DIFF
--- a/app/External/Slack/Modals/EquipmentAuthorization.php
+++ b/app/External/Slack/Modals/EquipmentAuthorization.php
@@ -221,16 +221,4 @@ class EquipmentAuthorization implements ModalInterface
 
         return $modal->updateViaApi($request);
     }
-
-    private function noEquipment()
-    {
-        $this->modalView->newSection()
-            ->mrkdwnText("Please select at least one piece of equipment above.");
-    }
-
-    private function noPerson()
-    {
-        $this->modalView->newSection()
-            ->mrkdwnText("Please select at least one member to authorize.");
-    }
 }

--- a/app/External/Slack/Modals/EquipmentAuthorization.php
+++ b/app/External/Slack/Modals/EquipmentAuthorization.php
@@ -32,14 +32,6 @@ class EquipmentAuthorization implements ModalInterface
 
     public function __construct()
     {
-        $this->setUpModalCommon();
-
-        $this->noEquipment();
-        $this->noPerson();
-    }
-
-    private function setUpModalCommon()
-    {
         $this->modalView = Kit::newModal()
             ->callbackId(self::callbackId())
             ->title('Equipment Authorization')
@@ -181,20 +173,11 @@ class EquipmentAuthorization implements ModalInterface
     public static function onBlockAction(SlackRequest $request)
     {
         $modal = new EquipmentAuthorization();
-        $modal->setUpModalCommon();
 
         $state = self::getStateValues($request);
 
         $selectedEquipment = self::equipmentFromState($state);
         $selectedMembers = self::peopleFromState($state);
-
-        if (empty($selectedEquipment)) {
-            $modal->noEquipment();
-        }
-
-        if (empty($selectedMembers)) {
-            $modal->noPerson();
-        }
         
         if (! empty($selectedEquipment) && ! empty($selectedMembers)) {
             // Render information about any selected people who have existing permisisons for this equipment.


### PR DESCRIPTION
This PR removes the "Please select at least one member..." and "Please select at least one piece of equipment..."
These changes spawned from [conversation](https://github.com/Denhac/denhac-webhooks/pull/48#discussion_r1451823809) in an earlier, unrelated pr.

The select fields are already required and come with built-in error messages that are shown on form submission and cleared on field change. This makes our custom warnings unnecessary.

This allows us to merge the `setupModalCommon` into the constructor.

Before:

![Screenshot 2024-01-18 at 11 27 28 AM](https://github.com/Denhac/denhac-webhooks/assets/22403528/8ced4945-8cd4-4157-97f5-fd893626a7ac)


After:
![Screenshot 2024-01-18 at 11 22 11 AM](https://github.com/Denhac/denhac-webhooks/assets/22403528/098c52f8-4d2c-4647-afe8-3d801e337004)


Error Progression:

![EquipAuthRemoveCopyErrorProgression](https://github.com/Denhac/denhac-webhooks/assets/22403528/059db5e6-e53d-473e-9f75-cdd93be315f4)


