### PR TITLE
[Slack][Equipment Authorization] Fix usage of empty on Collections

### DIFF
--- a/app/External/Slack/Modals/EquipmentAuthorization.php
+++ b/app/External/Slack/Modals/EquipmentAuthorization.php
@@ -205,7 +205,8 @@ class EquipmentAuthorization implements ModalInterface
                 }
             }
 
-            // NOTE: $alreadyTrained and $alreadyTrainers are arrays, where as most other iterables in this function are Collections
+            // NOTE: $alreadyTrained and $alreadyTrainers are arrays, where as most other iterables in this function are Collections.
+            // Use `empty` on arrays, and `Collection->isEmpty` on Collections.
             if (!empty($alreadyTrained) || !empty($alreadyTrainers)) {
                 // Render an information section which displays existing permissions
                 $modal->modalView->newSection()->mrkdwnText(":information_source:");

--- a/app/External/Slack/Modals/EquipmentAuthorization.php
+++ b/app/External/Slack/Modals/EquipmentAuthorization.php
@@ -179,7 +179,7 @@ class EquipmentAuthorization implements ModalInterface
         $selectedEquipment = self::equipmentFromState($state);
         $selectedMembers = self::peopleFromState($state);
         
-        if (! empty($selectedEquipment) && ! empty($selectedMembers)) {
+        if ($selectedEquipment->isNotEmpty() && $selectedMembers->isNotEmpty()) {
             // Render information about any selected people who have existing permisisons for this equipment.
 
             $alreadyTrained = [];
@@ -198,15 +198,15 @@ class EquipmentAuthorization implements ModalInterface
                         $trainerForEquipment[] = $equipment->name;
                     }
                 }
-                if (!empty($trainedEquipment)) {
+                if ($trainedEquipment->isNotEmpty()) {
                     $alreadyTrained[$name] = $trainedEquipment;
                 }
-                if (!empty($trainerForEquipment)) {
+                if ($trainerForEquipment->isNotEmpty()) {
                     $alreadyTrainers[$name] = $trainerForEquipment;
                 }
             }
 
-            if (!empty($alreadyTrained) || !empty($alreadyTrainers)) {
+            if ($alreadyTrained->isNotEmpty() || $alreadyTrainers->isNotEmpty()) {
                 $modal->modalView->newSection()->mrkdwnText(":information_source:");
 
                 foreach($alreadyTrained as $trainee => $equipmentNames) {

--- a/app/External/Slack/Modals/EquipmentAuthorization.php
+++ b/app/External/Slack/Modals/EquipmentAuthorization.php
@@ -172,6 +172,7 @@ class EquipmentAuthorization implements ModalInterface
 
     public static function onBlockAction(SlackRequest $request)
     {
+        // Rerender view to display information about any permissions that the users already have for this equipment.
         $modal = new EquipmentAuthorization();
 
         $state = self::getStateValues($request);
@@ -180,41 +181,41 @@ class EquipmentAuthorization implements ModalInterface
         $selectedMembers = self::peopleFromState($state);
         
         if ($selectedEquipment->isNotEmpty() && $selectedMembers->isNotEmpty()) {
-            // Render information about any selected people who have existing permisisons for this equipment.
 
             $alreadyTrained = [];
             $alreadyTrainers = [];
 
             foreach($selectedMembers as $person) {
-                $name = "{$person->first_name} {$person->last_name}";
-                $trainedEquipment = [];
-                $trainerForEquipment = [];
+                $traineeName = "{$person->first_name} {$person->last_name}";
+                
+                // Get names of equipment for which the member is already a user
+                $trainedEquipmentNames = $selectedEquipment
+                    ->where(fn($e) => $person->hasMembership($e->user_plan_id))
+                    ->map(fn($e) => $e->name);
+                if ($trainedEquipmentNames->isNotEmpty()) {
+                    $alreadyTrained[$traineeName] = $trainedEquipmentNames;
+                }
 
-                foreach($selectedEquipment as $equipment) {
-                    if ($person->hasMembership($equipment->user_plan_id)) {
-                        $trainedEquipment[] = $equipment->name;
-                    }
-                    if ($person->hasMembership($equipment->trainer_plan_id)) {
-                        $trainerForEquipment[] = $equipment->name;
-                    }
-                }
-                if ($trainedEquipment->isNotEmpty()) {
-                    $alreadyTrained[$name] = $trainedEquipment;
-                }
-                if ($trainerForEquipment->isNotEmpty()) {
-                    $alreadyTrainers[$name] = $trainerForEquipment;
+                // Get names of equipment for which the member is already a trainer
+                $trainerForEquipmentNames = $selectedEquipment
+                    ->where(fn($e) => $person->hasMembership($e->trainer_plan_id))
+                    ->map(fn($e) => $e->name);
+                if ($trainerForEquipmentNames->isNotEmpty()) {
+                    $alreadyTrainers[$traineeName] = $trainerForEquipmentNames;
                 }
             }
 
-            if ($alreadyTrained->isNotEmpty() || $alreadyTrainers->isNotEmpty()) {
+            // NOTE: $alreadyTrained and $alreadyTrainers are arrays, where as most other iterables in this function are Collections
+            if (!empty($alreadyTrained) || !empty($alreadyTrainers)) {
+                // Render an information section which displays existing permissions
                 $modal->modalView->newSection()->mrkdwnText(":information_source:");
 
                 foreach($alreadyTrained as $trainee => $equipmentNames) {
-                    $modal->modalView->newContext()->mrkdwnText($trainee.' is already trained on '.implode(', ', $equipmentNames));
+                    $modal->modalView->newContext()->mrkdwnText($trainee.' is already trained on '.$equipmentNames->join(', '));
                 }
 
                 foreach($alreadyTrainers as $trainer => $equipmentNames) {
-                    $modal->modalView->newContext()->mrkdwnText($trainer.' is already a trainer for '.implode(', ', $equipmentNames));
+                    $modal->modalView->newContext()->mrkdwnText($trainer.' is already a trainer for '.$equipmentNames->join(', '));
                 }
             }
         }

--- a/app/External/Slack/Modals/EquipmentAuthorization.php
+++ b/app/External/Slack/Modals/EquipmentAuthorization.php
@@ -32,14 +32,6 @@ class EquipmentAuthorization implements ModalInterface
 
     public function __construct()
     {
-        $this->setUpModalCommon();
-
-        $this->noEquipment();
-        $this->noPerson();
-    }
-
-    private function setUpModalCommon()
-    {
         $this->modalView = Kit::newModal()
             ->callbackId(self::callbackId())
             ->title('Equipment Authorization')
@@ -181,20 +173,11 @@ class EquipmentAuthorization implements ModalInterface
     public static function onBlockAction(SlackRequest $request)
     {
         $modal = new EquipmentAuthorization();
-        $modal->setUpModalCommon();
 
         $state = self::getStateValues($request);
 
         $selectedEquipment = self::equipmentFromState($state);
         $selectedMembers = self::peopleFromState($state);
-
-        if (empty($selectedEquipment)) {
-            $modal->noEquipment();
-        }
-
-        if (empty($selectedMembers)) {
-            $modal->noPerson();
-        }
         
         if (! empty($selectedEquipment) && ! empty($selectedMembers)) {
             // Render information about any selected people who have existing permisisons for this equipment.


### PR DESCRIPTION
This PR replaces erroneous usage of PHP's `empty` function on instances of Laravel's `Collection` class. It also migrates some nearby arrays to collections so that they can use consistent methods. It reorganizes some code and adds comments to clarify intent.

This issue was [raised](https://github.com/Denhac/denhac-webhooks/pull/48#pullrequestreview-1820320655) on an unrelated pull request.