### PR TITLE
Better handling of failed GitHub invites

### DIFF
--- a/app/Actions/GitHub/AddToGitHubTeam.php
+++ b/app/Actions/GitHub/AddToGitHubTeam.php
@@ -20,6 +20,6 @@ class AddToGitHubTeam
 
     public function execute($username, $team)
     {
-        $this->githubApi->team($team)->add($username);
+        $this->githubApi->denhac()->team($team)->add($username);
     }
 }

--- a/app/Actions/GitHub/RemoveFromGitHubTeam.php
+++ b/app/Actions/GitHub/RemoveFromGitHubTeam.php
@@ -20,6 +20,6 @@ class RemoveFromGitHubTeam
 
     public function execute($username, $team)
     {
-        $this->gitHubApi->team($team)->remove($username);
+        $this->gitHubApi->denhac()->team($team)->remove($username);
     }
 }

--- a/app/Console/Commands/ClearOutFailedGitHubInvites.php
+++ b/app/Console/Commands/ClearOutFailedGitHubInvites.php
@@ -15,7 +15,7 @@ class ClearOutFailedGitHubInvites extends Command
 {
     use HasApiProgressBar;
 
-    protected $signature = 'app:clear-out-failed-git-hub-invites {--dry-run}';
+    protected $signature = 'denhac:clear-out-failed-git-hub-invites {--dry-run}';
 
     protected $description = 'Members can add their GitHub username to their profile, but they don\'t always accept the
     invite and it expires after 7 days. GitHub keeps those and we can check against our customer\'s. If there\'s a

--- a/app/Console/Commands/ClearOutFailedGitHubInvites.php
+++ b/app/Console/Commands/ClearOutFailedGitHubInvites.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\External\GitHub\GitHubApi;
+use App\External\HasApiProgressBar;
+use App\External\WooCommerce\Api\WooCommerceApi;
+use App\Models\Customer;
+use App\Notifications\GitHubInviteExpired;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Str;
+
+class ClearOutFailedGitHubInvites extends Command
+{
+    use HasApiProgressBar;
+
+    protected $signature = 'app:clear-out-failed-git-hub-invites {--dry-run}';
+
+    protected $description = 'Members can add their GitHub username to their profile, but they don\'t always accept the
+    invite and it expires after 7 days. GitHub keeps those and we can check against our customer\'s. If there\'s a
+    failed invite, we update their profile to remove the GitHub username (they can add it back) and email them if they
+    are a current member letting them know about the issue.';
+
+    private GitHubApi $gitHubApi;
+    private WooCommerceApi $wooCommerceApi;
+
+    public function __construct(
+        GitHubApi      $gitHubApi,
+        WooCommerceApi $wooCommerceApi
+    )
+    {
+        parent::__construct();
+
+        $this->gitHubApi = $gitHubApi;
+        $this->wooCommerceApi = $wooCommerceApi;
+    }
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $isDryRun = $this->option('dry-run');
+        if ($isDryRun) {
+            $this->line('Dry run, will not actually update anything.');
+        }
+
+        $inOrganization = $this->gitHubApi->denhac()
+            ->list($this->apiProgress("GitHub in Organization"))
+            ->map(fn($ghm) => $ghm['login']);
+        $pendingInvitations = $this->gitHubApi->denhac()
+            ->list($this->apiProgress("GitHub pending invitation"))
+            ->map(fn($ghm) => $ghm['login']);
+        $failedInvites = $this->gitHubApi->denhac()
+            ->failed_invitations($this->apiProgress("GitHub failed invitations"))
+            ->map(fn($ghm) => $ghm['login']);
+        $this->info("We have {$failedInvites->count()} failed invites");
+
+        $customers = Customer::whereNotNull('github_username')->where('member', true)->get();
+        $this->info("We have {$customers->count()} that we need to verify");
+
+        foreach ($customers as $customer) {
+            /** @var Customer $customer */
+            $isInOrganization = $inOrganization
+                ->filter(fn($username) => Str::lower($username) == Str::lower($customer->github_username))
+                ->isNotEmpty();
+            $isPending = $pendingInvitations
+                ->filter(fn($username) => Str::lower($username) == Str::lower($customer->github_username))
+                ->isNotEmpty();
+            $hasFailedInvite = $failedInvites
+                ->filter(fn($username) => Str::lower($username) == Str::lower($customer->github_username))
+                ->isNotEmpty();
+
+            if($isInOrganization || $isPending) {
+                // If they're in the organization already or they're pending, we won't check any failed invites. Failed
+                // invites persist even if someone has been invited again.
+                continue;
+            }
+
+            if (!$hasFailedInvite) {
+                continue;  // This user is either in the GitHub organization or has been invited and that hasn't expired
+            }
+
+            $this->info("$customer->first_name $customer->last_name has a failed invite for GitHub username $customer->github_username");
+
+            if (! $isDryRun) {
+                $this->wooCommerceApi->customers
+                    ->update($customer->id, [
+                        'meta_data' => [
+                            [
+                                'key' => 'github_username',
+                                'value' => null,
+                            ],
+                        ],
+                    ]);
+
+                Notification::route('mail', $customer->email)->notify(new GitHubInviteExpired());
+            }
+        }
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -5,6 +5,7 @@ namespace App\Console;
 use App\Actions\QuickBooks\GenerateVendingNetJournalEntry;
 use App\Actions\Stripe\SetIssuingBalanceToValue;
 use App\Aggregates\CardNotifierAggregate;
+use App\Console\Commands\ClearOutFailedGitHubInvites;
 use App\Console\Commands\IdentifyIssues;
 use App\Console\Commands\LinkQuickbooks;
 use App\Console\Commands\MakeIssue;
@@ -27,6 +28,7 @@ class Kernel extends ConsoleKernel
      * @var array
      */
     protected $commands = [
+        ClearOutFailedGitHubInvites::class,
         IdentifyIssues::class,
         LinkQuickbooks::class,
         MakeIssue::class,

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -49,10 +49,11 @@ class Kernel extends ConsoleKernel
             })
             ->weeklyOn(Schedule::SATURDAY, '13:00');
 
-        $schedule->command('denhac:slack-profile-fields-update')
-            ->daily();
+        $schedule->command('denhac:slack-profile-fields-update')->daily();
 
         $schedule->command('passport:purge')->hourly();
+
+        $schedule->command('denhac:clear-out-failed-git-hub-invites')->daily();
 
         // QuickBooks tokens expire every hour. Every half should prevent any issues with a job running right as a token expires.
         $schedule->call(fn () => $this->refreshQuickBooksAccessToken())->everyThirtyMinutes();

--- a/app/External/GitHub/GitHubApi.php
+++ b/app/External/GitHub/GitHubApi.php
@@ -24,10 +24,19 @@ class GitHubApi
         return $this->accessToken;
     }
 
-    public function team($name)
+    public function organizations($name): OrganizationApi
     {
-        // TODO switch this to be under orgs even though we'll almost always be using denhac
-        return new TeamApi($name, $this->getAccessToken());
+        return new OrganizationApi($name, $this->getAccessToken());
+    }
+
+    /**
+     * Convenience function since we most often need to access the denhac organization.
+     *
+     * @return OrganizationApi
+     */
+    public function denhac(): OrganizationApi
+    {
+        return $this->organizations("denhac");
     }
 
     public function userLookup($username)

--- a/app/External/GitHub/OrganizationApi.php
+++ b/app/External/GitHub/OrganizationApi.php
@@ -35,7 +35,7 @@ class OrganizationApi
         return new TeamApi($this->organizationName, $name, $this->accessToken);
     }
 
-    public function list(ApiProgress $progress = null): Collection
+    public function listMembers(ApiProgress $progress = null): Collection
     {
         return $this->paginate("{$this->organizationUrl}/members", function ($url) {
             return $this->client->get($url, [
@@ -47,7 +47,7 @@ class OrganizationApi
         }, $progress);
     }
 
-    public function pending(ApiProgress $progress = null): Collection
+    public function pendingInvitations(ApiProgress $progress = null): Collection
     {
         return $this->paginate("{$this->organizationUrl}/invitations", function ($url) {
             return $this->client->get($url, [
@@ -59,7 +59,7 @@ class OrganizationApi
         }, $progress);
     }
 
-    public function failed_invitations(ApiProgress $progress = null): Collection
+    public function failedInvitations(ApiProgress $progress = null): Collection
     {
         return $this->paginate("{$this->organizationUrl}/failed_invitations", function ($url) {
             return $this->client->get($url, [

--- a/app/Issues/Checkers/GitHub/GitHubIssues.php
+++ b/app/Issues/Checkers/GitHub/GitHubIssues.php
@@ -71,7 +71,7 @@ class GitHubIssues implements IssueCheck
             $invited = $partOfTheTeam || $pendingOnTheTeam;
 
             if ($failedInvite) {
-                continue; // Nothing to do here  TODO Write a cron job that checks for this, removes their GitHub username from their account, and sends them an email about it IFF they're currently a member.
+                continue; // Nothing to do here. Failed invites should automatically be cleaned out.
             } elseif (!$invited && $member->isMember) {
                 $this->issues->add(new UsernameNotListedInMembersTeam($member));
             } elseif ($invited && !$member->isMember) {

--- a/app/Issues/IssueData.php
+++ b/app/Issues/IssueData.php
@@ -49,9 +49,11 @@ class IssueData
 
     private ?Collection $_googleGroupMembers = null;  // Key is group, value is member list
 
-    private ?Collection $_gitHubTeamMembers = null;  // The GitHub team is called "members"
+    private ?Collection $_gitHubMembers = null;  // The GitHub team is called "members"
 
-    private ?Collection $_gitHubPendingTeamMembers = null;  // The invites to said team
+    private ?Collection $_gitHubPendingMembers = null;  // The invites to said team
+
+    private ?Collection $_gitHubFailedInvites = null;  // The invites to said team that weren't accepted
 
     private ?Collection $_stripeCardHolders = null;
 
@@ -229,26 +231,34 @@ class IssueData
         return $this->_googleGroupMembers->get($group);
     }
 
-    public function gitHubTeamMembers(): Collection
+    public function gitHubMembers(): Collection
     {
-        if (is_null($this->_gitHubTeamMembers)) {
+        if (is_null($this->_gitHubMembers)) {
             // TODO Deduplicate "members" here
-            $this->_gitHubTeamMembers = $this->gitHubApi->denhac()->team('members')
-                ->list($this->apiProgress("Fetching members of GitHub team 'members'"));
+            $this->_gitHubMembers = $this->gitHubApi->denhac()->list($this->apiProgress("Fetching members of GitHub team 'members'"));
         }
 
-        return $this->_gitHubTeamMembers;
+        return $this->_gitHubMembers;
     }
 
-    public function gitHubPendingTeamMembers(): Collection
+    public function gitHubPendingMembers(): Collection
     {
-        if (is_null($this->_gitHubPendingTeamMembers)) {
+        if (is_null($this->_gitHubPendingMembers)) {
             // TODO Deduplicate "members" here
-            $this->_gitHubPendingTeamMembers = $this->gitHubApi->denhac()->team('members')
-                ->pending($this->apiProgress("Fetching invites of GitHub team 'members'"));
+            $this->_gitHubPendingMembers = $this->gitHubApi->denhac()->pending($this->apiProgress("Fetching invites of GitHub team 'members'"));
         }
 
-        return $this->_gitHubPendingTeamMembers;
+        return $this->_gitHubPendingMembers;
+    }
+
+    public function gitHubFailedInvites(): Collection
+    {
+        if (is_null($this->_gitHubFailedInvites)) {
+            // TODO Deduplicate "members" here
+            $this->_gitHubFailedInvites = $this->gitHubApi->denhac()->failed_invitations($this->apiProgress("Fetching invites of GitHub team 'members'"));
+        }
+
+        return $this->_gitHubFailedInvites;
     }
 
     public function stripeCardHolders(): Collection

--- a/app/Issues/IssueData.php
+++ b/app/Issues/IssueData.php
@@ -233,7 +233,7 @@ class IssueData
     {
         if (is_null($this->_gitHubTeamMembers)) {
             // TODO Deduplicate "members" here
-            $this->_gitHubTeamMembers = $this->gitHubApi->team('members')
+            $this->_gitHubTeamMembers = $this->gitHubApi->denhac()->team('members')
                 ->list($this->apiProgress("Fetching members of GitHub team 'members'"));
         }
 
@@ -244,7 +244,7 @@ class IssueData
     {
         if (is_null($this->_gitHubPendingTeamMembers)) {
             // TODO Deduplicate "members" here
-            $this->_gitHubPendingTeamMembers = $this->gitHubApi->team('members')
+            $this->_gitHubPendingTeamMembers = $this->gitHubApi->denhac()->team('members')
                 ->pending($this->apiProgress("Fetching invites of GitHub team 'members'"));
         }
 

--- a/app/Issues/IssueData.php
+++ b/app/Issues/IssueData.php
@@ -235,7 +235,7 @@ class IssueData
     {
         if (is_null($this->_gitHubMembers)) {
             // TODO Deduplicate "members" here
-            $this->_gitHubMembers = $this->gitHubApi->denhac()->list($this->apiProgress("Fetching members of GitHub team 'members'"));
+            $this->_gitHubMembers = $this->gitHubApi->denhac()->listMembers($this->apiProgress("Fetching members of GitHub team 'members'"));
         }
 
         return $this->_gitHubMembers;
@@ -245,7 +245,7 @@ class IssueData
     {
         if (is_null($this->_gitHubPendingMembers)) {
             // TODO Deduplicate "members" here
-            $this->_gitHubPendingMembers = $this->gitHubApi->denhac()->pending($this->apiProgress("Fetching invites of GitHub team 'members'"));
+            $this->_gitHubPendingMembers = $this->gitHubApi->denhac()->pendingInvitations($this->apiProgress("Fetching invites of GitHub team 'members'"));
         }
 
         return $this->_gitHubPendingMembers;
@@ -255,7 +255,7 @@ class IssueData
     {
         if (is_null($this->_gitHubFailedInvites)) {
             // TODO Deduplicate "members" here
-            $this->_gitHubFailedInvites = $this->gitHubApi->denhac()->failed_invitations($this->apiProgress("Fetching invites of GitHub team 'members'"));
+            $this->_gitHubFailedInvites = $this->gitHubApi->denhac()->failedInvitations($this->apiProgress("Fetching invites of GitHub team 'members'"));
         }
 
         return $this->_gitHubFailedInvites;

--- a/app/Issues/Types/GitHub/NonMemberInTeam.php
+++ b/app/Issues/Types/GitHub/NonMemberInTeam.php
@@ -39,7 +39,7 @@ class NonMemberInTeam extends IssueBase
             ->option('Remove from GitHub team', function () {
                 /** @var GitHubApi $gitHubApi */
                 $gitHubApi = app(GitHubApi::class);
-                $gitHubApi->team('members')->remove($this->member->githubUsername);
+                $gitHubApi->denhac()->team('members')->remove($this->member->githubUsername);
 
                 return true;
             })

--- a/app/Issues/Types/GitHub/UnknownGitHubUsernameInTeam.php
+++ b/app/Issues/Types/GitHub/UnknownGitHubUsernameInTeam.php
@@ -46,7 +46,7 @@ class UnknownGitHubUsernameInTeam extends IssueBase
     {
         /** @var GitHubApi $gitHubApi */
         $gitHubApi = app(GitHubApi::class);
-        $gitHubApi->team('members')->remove($this->gitHubUsername);
+        $gitHubApi->denhac()->team('members')->remove($this->gitHubUsername);
 
         return true;
     }

--- a/app/Issues/Types/GitHub/UsernameNotListedInMembersTeam.php
+++ b/app/Issues/Types/GitHub/UsernameNotListedInMembersTeam.php
@@ -39,7 +39,7 @@ class UsernameNotListedInMembersTeam extends IssueBase
             ->option('Add to GitHub team', function () {
                 /** @var GitHubApi $gitHubApi */
                 $gitHubApi = app(GitHubApi::class);
-                $gitHubApi->team('members')->add($this->member->githubUsername);
+                $gitHubApi->denhac()->team('members')->add($this->member->githubUsername);
 
                 return true;
             })

--- a/app/Notifications/GitHubInviteExpired.php
+++ b/app/Notifications/GitHubInviteExpired.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class GitHubInviteExpired extends Notification
+{
+    use Queueable;
+
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject("denhac GitHub invitation expired")
+            ->replyTo(config('denhac.access_email'))
+            ->line('Your invitation to the denhac GitHub organization has expired.')
+            ->line('If you\'d like to retry this, please re-enter your GitHub username on your account page.')
+            ->action("Go to My Account", "https://denhac.org/my-account");
+    }
+}

--- a/app/Reactors/GithubMembershipReactor.php
+++ b/app/Reactors/GithubMembershipReactor.php
@@ -20,7 +20,7 @@ final class GithubMembershipReactor extends Reactor
         if (! is_null($event->oldUsername)) {
             /** @var GitHubApi $gitHubApi */
             $gitHubApi = app(GitHubApi::class);
-            $gitHubUsers = $gitHubApi->team('members')->list()->map(fn ($ghm) => $ghm['login']);
+            $gitHubUsers = $gitHubApi->denhac()->team('members')->list()->map(fn ($ghm) => $ghm['login']);
 
             if ($gitHubUsers->contains($event->oldUsername)) {
                 RemoveFromGitHubTeam::queue()->execute($event->oldUsername, self::MEMBERS_TEAM);

--- a/tests/Unit/Reactors/GithubMembershipReactorTest.php
+++ b/tests/Unit/Reactors/GithubMembershipReactorTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Reactors;
 use App\Actions\GitHub\AddToGitHubTeam;
 use App\Actions\GitHub\RemoveFromGitHubTeam;
 use App\External\GitHub\GitHubApi;
+use App\External\GitHub\OrganizationApi;
 use App\External\GitHub\TeamApi;
 use App\Models\Customer;
 use App\Reactors\GithubMembershipReactor;
@@ -25,9 +26,14 @@ class GithubMembershipReactorTest extends TestCase
 
         $this->withOnlyEventHandlerType(GithubMembershipReactor::class);
 
+        $denhacOrganizationApi = $this->spy(OrganizationApi::class);
         $memberTeamApi = $this->spy(TeamApi::class);
         $gitHubApi = $this->spy(GitHubApi::class);
-        $gitHubApi->allows('team')
+        $gitHubApi->allows('denhac')->andReturn($denhacOrganizationApi);
+        $gitHubApi->allows('organization')
+            ->withArgs(['denhac'])
+            ->andReturn($denhacOrganizationApi);
+        $denhacOrganizationApi->allows('team')
             ->withArgs(['members'])
             ->andReturn($memberTeamApi);
         $memberTeamApi->allows('list')


### PR DESCRIPTION
I realized we could grab failed invitations, but that wasn't on the team level, it was only on the organization level. Given how we're inviting people to the team and it also invites them to the denhac GitHub organization, I decided this change would be part refactor of the API layer and part fixing an issue.

Before these changes, the issue checker would report an error for anyone who is a member, but their GitHub invitation expired before they accepted the invitation. This PR adds a command that will automatically clear these member's GitHub username in their profile as well as send them an email letting them know their invite expired and how to get a new invite.

Currently the issue checker in the webhooks project has 74 issues, 36 of which are affected by this issue.