### PR TITLE
Cleaned up equipment authorization code a little

### DIFF
--- a/app/Exceptions/UnauthorizedTrainerException.php
+++ b/app/Exceptions/UnauthorizedTrainerException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+use Throwable;
+
+class UnauthorizedTrainerException extends Exception
+{
+    public function __construct(int $trainerId, int $equipmentId, ?Throwable $previous = null)
+    {
+        $message = "Trainer $trainerId attempted to train for equipment $equipmentId but was not authorized to do so";
+        parent::__construct($message, 0, $previous);
+    }
+}


### PR DESCRIPTION
I started with wanting to make a custom exception class and remove the `return 'ok'` magic string, but PhpStorm pointed out a few other issues such as with type hinting or unused variables/imports that were much harder to see in the original PR.