### PR TITLE
Basic budget management

### DIFF
--- a/app/Actions/QuickBooks/GenerateVendingNetJournalEntry.php
+++ b/app/Actions/QuickBooks/GenerateVendingNetJournalEntry.php
@@ -46,8 +46,8 @@ class GenerateVendingNetJournalEntry
             // something.
         }
 
-        $begin = Carbon::create(year: $date->year, month: $date->month, day: $date->day, tz: $date->timezone);
-        $end = Carbon::make($begin)->addDay()->subSecond();
+        $begin = $date->startOfDay();
+        $end = $date->endOfDay();
 
         $wooCommerceOrders = $this->wooCommerceApi->orders->list([
             'after' => $begin->toIso8601String(),

--- a/app/Actions/QuickBooks/GetAmountSpentByClass.php
+++ b/app/Actions/QuickBooks/GetAmountSpentByClass.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Actions\QuickBooks;
+
+use Carbon\Carbon;
+use QuickBooksOnline\API\DataService\DataService;
+use QuickBooksOnline\API\ReportService\ReportName;
+use QuickBooksOnline\API\ReportService\ReportService;
+
+/**
+ * Runs a report through QuickBooks to determine spend per QuickBooks class.
+ */
+class GetAmountSpentByClass
+{
+    public function execute($classId, Carbon $startDate, Carbon $endDate): float
+    {
+        /** @var DataService $dataService */
+        $dataService = app(DataService::class);
+
+        $serviceContext = $dataService->getServiceContext();
+
+        $reportService = new ReportService($serviceContext);
+        $reportService->setStartDate($startDate->format("Y-m-d"));
+        $reportService->setEndDate($endDate->format("Y-m-d"));
+        $reportService->setClassid($classId);
+        $reportService->setAccountingMethod("Accrual");
+
+        /** @var \stdClass $profitAndLossReport */
+        $profitAndLossReport = $reportService->executeReport(ReportName::PROFITANDLOSS);
+
+        // QuickBooks reports can be very nested which makes the format a little hard to parse. One consistency is the
+        // columns are all the same for every level of the nesting so we start by grabbing the column index for the
+        // "total"
+        $columns = collect($profitAndLossReport->Columns->Column)->map(function ($column) {
+            return $column->MetaData[0]->Value;
+        })->values();
+        $totalColumn = $columns->search("total");
+
+        // We then look for the "NetIncome" group (also called "Net Revenue in the row itself") and extract the net
+        // revenue value.
+        $netRevenueSection = collect($profitAndLossReport->Rows->Row)->first(function ($row) {
+            return $row->group == "NetIncome";
+        });
+        $netRevenueData = collect($netRevenueSection->Summary->ColData)->map(function ($colData) {
+            return $colData->value;
+        });
+        $netRevenue = floatval($netRevenueData[$totalColumn]);
+
+        if(abs($netRevenue) < 0.01) {  // Handles 0 and anything less than a penny though I didn't see that in practice
+            return 0;
+        }
+
+        // Net income is usually negative for budgets since it's all outgoing and no incoming. We want to return spend
+        // so we negate that value.
+        return -$netRevenue;
+    }
+}

--- a/app/Actions/QuickBooks/PullCurrentlyUsedAmountForBudgetFromQuickBooks.php
+++ b/app/Actions/QuickBooks/PullCurrentlyUsedAmountForBudgetFromQuickBooks.php
@@ -23,16 +23,14 @@ class PullCurrentlyUsedAmountForBudgetFromQuickBooks
         /** @var GetAmountSpentByClass $getAmountSpentByClass */
         $getAmountSpentByClass = app(GetAmountSpentByClass::class);
 
-        // TODO I don't think there's a timezone bug here, but still need to check
-        // Some things suggest it's Pacific time and others suggest that it's local to the QBO install. We'd need a
-        // transaction that would be in one day if it was pacific and in another if it was local to test.
-        $today = Carbon::today();
+        // The QuickBooks API, when it does not use a date time offset, always uses PST as its time zone.
+        $today = Carbon::today('PST');
 
         switch ($budget->type) {
             case Budget::TYPE_ONE_TIME:
             case Budget::TYPE_POOL:
                 // Date from before we were using quickbooks to catch everything until now
-                $startDate = Carbon::create(2019);
+                $startDate = Carbon::create(2019, tz: 'PST');
                 $endDate = $today->copy()->endOfDay();
                 break;
             case Budget::TYPE_RECURRING_MONTHLY:

--- a/app/Actions/QuickBooks/PullCurrentlyUsedAmountForBudgetFromQuickBooks.php
+++ b/app/Actions/QuickBooks/PullCurrentlyUsedAmountForBudgetFromQuickBooks.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Actions\QuickBooks;
+
+use App\Actions\StaticAction;
+use App\Models\Budget;
+use Carbon\Carbon;
+
+/**
+ *
+ */
+class PullCurrentlyUsedAmountForBudgetFromQuickBooks
+{
+    use StaticAction;
+
+    public function execute(Budget $budget): void
+    {
+        $currentlyUsed = $budget->currently_used;
+
+        /** @var GetAmountSpentByClass $getAmountSpentByClass */
+        $getAmountSpentByClass = app(GetAmountSpentByClass::class);
+
+        $today = Carbon::now();  // TODO I don't think there's a timezone bug here, but still need to check
+        switch ($budget->type) {
+            case Budget::TYPE_ONE_TIME:
+            case Budget::TYPE_POOL:
+                // Date from before we were using quickbooks to catch everything until now
+                $startDate = Carbon::createFromDate(2019, 1, 1);
+                $endDate = $today;
+                break;
+            case Budget::TYPE_RECURRING_MONTHLY:
+                $startDate = $today->startOfMonth();
+                $endDate = $today->endOfMonth();
+                break;
+            case Budget::TYPE_RECURRING_YEARLY:
+                $startDate = $today->startOfYear();
+                $endDate = $today->endOfYear();
+                break;
+            default:
+                throw new \Exception("Unknown budget type $budget->type");
+        }
+
+        $quickBooksCurrentlyUsed = $getAmountSpentByClass->execute($budget->quickbooks_class_id, $startDate, $endDate);
+
+        if($budget->type == Budget::TYPE_POOL) {
+            // For a pool, the "spend" we just fetched is the negative of the amount we have available to use. i.e if
+            // the "amount spent" retrieved above is -700.00 then that means our pool has $700.00 it can use. If our
+            // allocated amount is $1,000.00 we can consider that $300.00 used. To make the math easier almost
+            // everywhere else, we calculate how much we've "used" based on how much is allocated. The only other place
+            // we have to care about this is when updating the allocated_amount field.
+            $quickBooksCurrentlyUsed = $budget->allocated_amount + $quickBooksCurrentlyUsed;
+        }
+
+        if (abs($quickBooksCurrentlyUsed - $currentlyUsed) < 0.01) {
+            $budget->currently_used = $quickBooksCurrentlyUsed;
+            $budget->save();
+            // TODO Trigger any "go update the cards" stuff here?
+        }
+    }
+}

--- a/app/Actions/Stripe/UpdateAllStripeCardsFromBudgets.php
+++ b/app/Actions/Stripe/UpdateAllStripeCardsFromBudgets.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace App\Actions\Stripe;
+
+use App\External\Stripe\SpendingControls;
+use App\External\Stripe\SpendingLimits;
+use App\Models\Budget;
+use App\Models\Customer;
+use App\Models\StripeCard;
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+use Spatie\QueueableAction\QueueableAction;
+
+class UpdateAllStripeCardsFromBudgets
+{
+    use QueueableAction;
+
+    public function __construct()
+    {
+
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function execute()
+    {
+        /** @var UpdateSpendingLimitsOnCard $updateSpendingLimitsOnCard */
+        $updateSpendingLimitsOnCard = app(UpdateSpendingLimitsOnCard::class);
+
+        $cardsToSpendingLimit = collect();
+        $issuingBalance = 0;
+
+        foreach (Budget::all() as $budget) {
+            /** @var Budget $budget */
+            if(! $budget->active) {
+                // This budget isn't active, so we ignore it for all top-up and spending limit purposes. Any cards that
+                // are only attached to this budget will have their spending limit set to a penny.
+                continue;
+            }
+
+            $cards = $this->getCardsThatCanSpend($budget);
+
+            $budgetAvailable = $budget->available_to_spend;
+
+            foreach($cards as $stripeCard) {
+                $currentAmount = $cardsToSpendingLimit->get($stripeCard->id, 0);
+                $currentAmount += $budgetAvailable;
+                $cardsToSpendingLimit->put($stripeCard->id, $currentAmount);
+            }
+
+            if($cards->isNotEmpty()) {
+                $issuingBalance += $budgetAvailable;
+            }
+        }
+
+        foreach(StripeCard::all() as $stripeCard) {
+            if($stripeCard->status == StripeCard::STATUS_CANCELED) {
+                // Canceled is permanent, spending limits don't matter at all.
+                continue;
+            }
+
+            // $0.01 since we can't set it to 0. Effectively disables the card if no spend is available.
+            $spendingLimit = $cardsToSpendingLimit->get($stripeCard->id, 0.01);
+            $spendingLimitInPennies = round($spendingLimit * 100);
+
+            $limits = (new SpendingLimits($spendingLimitInPennies))->per_authorization();
+            $controls = (new SpendingControls())->spending_limits($limits);
+            $updateSpendingLimitsOnCard->onQueue()->execute($stripeCard, $controls);
+        }
+
+        $issuingBalanceInPennies = round($issuingBalance * 100);
+
+        if($issuingBalanceInPennies > 0) {
+            /** @var SetIssuingBalanceToValue $setIssuingBalanceToValue */
+            $setIssuingBalanceToValue = app(SetIssuingBalanceToValue::class);
+            $today = Carbon::today('America/Denver');
+            $message = "Top-Up to match current outstanding budgets {$today->toFormattedDayDateString()}";
+            $setIssuingBalanceToValue->onQueue()->execute($issuingBalanceInPennies, $message);
+        }
+    }
+
+    /**
+     * @param Budget $budget
+     * @return Collection<StripeCard>
+     * @throws \Exception
+     */
+    private function getCardsThatCanSpend(Budget $budget): Collection
+    {
+        $owner = $budget->owner;
+
+        if(is_a($owner, Customer::class)) {
+            if(! $owner->member) {
+                // Doesn't matter if they have a physical card or not, we'll pretend they don't so any physical cards
+                // they do have get set to a spending limit of a penny.
+                return collect();
+            }
+
+            if(is_null($owner->stripe_card_holder_id)) {
+                // This person might have a card, but the card holder in stripe hasn't been associated to their account
+                // just yet. We limit their spending to be safe.
+                return collect();
+            }
+
+            $stripeCard = StripeCard::where('cardholder_id', $owner->stripe_card_holder_id)
+                ->where('status', StripeCard::STATUS_ACTIVE)
+                ->where('type', StripeCard::TYPE_PHYSICAL)
+                ->first();
+
+            if(is_null($stripeCard)) {
+                return collect();
+            }
+
+            return collect([$stripeCard]);
+
+        } else {
+            $owner_type = get_class($owner);
+            throw new \Exception("Unknown owner type: {$owner_type}");
+        }
+    }
+}

--- a/app/Actions/Stripe/UpdateCardsFromSource.php
+++ b/app/Actions/Stripe/UpdateCardsFromSource.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Actions\Stripe;
+
+use App\Models\StripeCard;
+use Spatie\QueueableAction\QueueableAction;
+use Stripe\Issuing\Card;
+use Stripe\StripeClient;
+
+class UpdateCardsFromSource
+{
+    use QueueableAction;
+
+    private StripeClient $stripeClient;
+
+    public function __construct(StripeClient $stripeClient)
+    {
+        $this->stripeClient = $stripeClient;
+    }
+
+    public function execute()
+    {
+        $cards = $this->stripeClient->issuing->cards->all()->autoPagingIterator();
+
+        $stripeModels = StripeCard::all();
+        $seenCardIds = collect();
+
+        foreach ($cards as $card) {
+            /** @var Card $card */
+            $cardModel = $stripeModels->firstWhere('id', $card->id);
+
+            if (is_null($cardModel)) {
+                $cardModel = StripeCard::make([
+                    'id' => $card->id,
+                    'cardholder_id' => $card->cardholder->id,
+                ]);
+            }
+
+            $cardModel->type = $card->type;
+            $cardModel->status = $card->status;
+
+            $cardModel->save();
+
+            $seenCardIds->push($card->id);
+        }
+    }
+}

--- a/app/Actions/Stripe/UpdateSpendingLimitsOnCard.php
+++ b/app/Actions/Stripe/UpdateSpendingLimitsOnCard.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Actions\Stripe;
+
+use App\External\Stripe\SpendingControls;
+use App\Models\StripeCard;
+use Spatie\QueueableAction\QueueableAction;
+use Stripe\StripeClient;
+
+class UpdateSpendingLimitsOnCard
+{
+    use QueueableAction;
+
+    private StripeClient $client;
+
+    public function __construct(StripeClient $client)
+    {
+        $this->client = $client;
+    }
+
+    public function execute(StripeCard $stripeCard, SpendingControls $controls)
+    {
+        return $this->client->issuing->cards
+            ->update($stripeCard->id,
+                [
+                    'spending_controls' => $controls->stripeObject()->toArray(),
+                ]
+            );
+    }
+}

--- a/app/Actions/Stripe/UpdateStripeCardsFromSource.php
+++ b/app/Actions/Stripe/UpdateStripeCardsFromSource.php
@@ -7,7 +7,7 @@ use Spatie\QueueableAction\QueueableAction;
 use Stripe\Issuing\Card;
 use Stripe\StripeClient;
 
-class UpdateCardsFromSource
+class UpdateStripeCardsFromSource
 {
     use QueueableAction;
 
@@ -23,7 +23,6 @@ class UpdateCardsFromSource
         $cards = $this->stripeClient->issuing->cards->all()->autoPagingIterator();
 
         $stripeModels = StripeCard::all();
-        $seenCardIds = collect();
 
         foreach ($cards as $card) {
             /** @var Card $card */
@@ -40,8 +39,6 @@ class UpdateCardsFromSource
             $cardModel->status = $card->status;
 
             $cardModel->save();
-
-            $seenCardIds->push($card->id);
         }
     }
 }

--- a/app/Console/Commands/PrintQuickBooksBudgets.php
+++ b/app/Console/Commands/PrintQuickBooksBudgets.php
@@ -2,51 +2,45 @@
 
 namespace App\Console\Commands;
 
+use App\Actions\QuickBooks\GetAmountSpentByClass;
 use App\External\QuickBooks\QuickBookReferences;
+use Carbon\Carbon;
 use Illuminate\Console\Command;
-use QuickBooksOnline\API\Data\IPPClass;
 use QuickBooksOnline\API\DataService\DataService;
-use QuickBooksOnline\API\ReportService\ReportName;
-use QuickBooksOnline\API\ReportService\ReportService;
 
 class PrintQuickBooksBudgets extends Command
 {
     protected $signature = 'denhac:print-quick-books-budgets';
 
     protected $description = 'This is just a test command to print QuickBooks budgets';
+    private GetAmountSpentByClass $getAmountSpentByClass;
+
+    public function __construct(
+        GetAmountSpentByClass $getAmountSpentByClass
+    )
+    {
+        parent::__construct();
+
+        $this->getAmountSpentByClass = $getAmountSpentByClass;
+    }
 
     public function handle()
     {
         /** @var DataService $dataService */
         $dataService = app(DataService::class);
-        $serviceContext = $dataService->getServiceContext();
         $references = app(QuickBookReferences::class);
         $classes = collect($dataService->FindAll('Class'));
 
         $activeBudgets = $classes->filter(fn($class) => $class->ParentRef == $references->budgetClassActive->value);
 
         foreach ($activeBudgets as $budget) {
-            /** @var IPPClass $budget */
-            $reportService = new ReportService($serviceContext);
-            $reportService->setStartDate("2019-01-01");
-            $reportService->setEndDate("2024-01-25");
-            $reportService->setClassid($budget->Id);
-            $reportService->setAccountingMethod("Accrual");
-            /** @var \stdClass $profitAndLossReport */
-            $profitAndLossReport = $reportService->executeReport(ReportName::PROFITANDLOSS);
-            $columns = collect($profitAndLossReport->Columns->Column)->map(function ($column) {
-                return $column->MetaData[0]->Value;
-            })->values();
-            $netRevenueSection = collect($profitAndLossReport->Rows->Row)->first(function ($row) {
-                return $row->group == "NetIncome";
-            });
-            $netRevenueData = collect($netRevenueSection->Summary->ColData)->map(function ($colData) {
-                return $colData->value;
-            });
+            $spent = $this->getAmountSpentByClass->execute(
+                $budget->id,
+                Carbon::createFromDate(2019, 1, 1),
+                Carbon::now()
+            );
 
-            $totalColumn = $columns->search("total");
-            $value = -floatval($netRevenueData[$totalColumn]);
-            $this->info("{$budget->Name}\tSpent: $value");
+            $this->info("{$budget->Name}\tSpent: $spent");
         }
     }
 }

--- a/app/External/Stripe/SpendingControls.php
+++ b/app/External/Stripe/SpendingControls.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\External\Stripe;
+
+use Stripe\StripeObject;
+
+class SpendingControls
+{
+    private array $spending_limits = [];
+
+    public function stripeObject(): StripeObject
+    {
+        $stripeObject = new StripeObject();
+
+        if (count($this->spending_limits) > 0) {
+            $stripeObject->spending_limits = array_map(fn($sl) => $sl->stripeObject(), $this->spending_limits);
+        }
+
+        return $stripeObject;
+    }
+
+    public function spending_limits(SpendingLimits ...$limits): SpendingControls
+    {
+        $this->spending_limits = $limits;
+
+        return $this;
+    }
+}

--- a/app/External/Stripe/SpendingLimits.php
+++ b/app/External/Stripe/SpendingLimits.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\External\Stripe;
+
+use Stripe\StripeObject;
+
+class SpendingLimits
+{
+    private int $amount;
+    private string $interval;
+
+    public function __construct(
+        $amount = 500_00,  // $500.00
+    )
+    {
+        $this->amount = $amount;
+        $this->interval = "all_time";
+    }
+
+    public function stripeObject(): StripeObject
+    {
+        $stripeObject = new StripeObject();
+
+        $stripeObject->amount = $this->amount;
+        $stripeObject->interval = $this->interval;
+
+        return $stripeObject;
+    }
+
+    public function daily(): SpendingLimits
+    {
+        $this->interval = "daily";
+        return $this;
+    }
+
+    public function weekly(): SpendingLimits
+    {
+        $this->interval = "weekly";
+        return $this;
+    }
+
+    public function monthly(): SpendingLimits
+    {
+        $this->interval = "monthly";
+        return $this;
+    }
+
+    public function yearly(): SpendingLimits
+    {
+        $this->interval = "yearly";
+        return $this;
+    }
+
+    public function per_authorization(): SpendingLimits
+    {
+        $this->interval = "per_authorization";
+        return $this;
+    }
+}

--- a/app/External/Stripe/StripeIdGenerator.php
+++ b/app/External/Stripe/StripeIdGenerator.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\External\Stripe;
+
+use Faker\Generator;
+
+class StripeIdGenerator
+{
+    private const ID_CHARACTERS = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q',
+        'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+        'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',];
+
+    public static function make($prefix): string
+    {
+        $faker = app(Generator::class);
+        return $prefix . '_' . implode('', $faker->randomElements(self::ID_CHARACTERS, 24, true));
+    }
+}

--- a/app/Models/Budget.php
+++ b/app/Models/Budget.php
@@ -45,6 +45,7 @@ class Budget extends Model
     protected $appends = [
         'available_to_spend',
     ];
+
     protected function allocated_amount(): Attribute
     {
         return Attribute::make(
@@ -75,7 +76,7 @@ class Budget extends Model
      */
     public function getAvailableToSpendAttribute(): float
     {
-        $canSpend = $this->allocated_amount - $this->available_to_spend;
+        $canSpend = $this->allocated_amount - $this->currently_used;
 
         // Less than a penny or already over budget? No spend for you!
         if($canSpend < 0.01) {

--- a/app/Models/Budget.php
+++ b/app/Models/Budget.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace App\Models;
+
+use App\Actions\QuickBooks\GetAmountSpentByClass;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+/**
+ * @property string quickbooks_class_id
+ * @property string name
+ * @property string type
+ * @property boolean active
+ * @property float allocated_amount
+ * @property float currently_used
+ * @property string notes
+ * @property Customer owner
+ *
+ * @property float available_to_spend;
+ */
+class Budget extends Model
+{
+    public const TYPE_ONE_TIME = 'one-time';
+    public const TYPE_RECURRING_MONTHLY = 'recurring-monthly';
+    public const TYPE_RECURRING_YEARLY = 'recurring-yearly';
+    public const TYPE_POOL = 'pool';
+
+    protected $fillable = [
+        'quickbooks_class_id',
+        'name',
+        'type',
+        'active',
+        'allocated_amount',
+        'currently_used',
+        'owner_type',
+        'owner_id',
+        'notes',
+    ];
+
+    protected $appends = [
+        'available_to_spend',
+    ];
+
+    use HasFactory;
+
+    /**
+     * Sync the currently used amount down from QuickBooks
+     *
+     * @return void
+     * @throws \Exception
+     */
+    public function syncCurrentlyUsed(): void
+    {
+        $currentlyUsed = $this->currently_used;
+
+        /** @var GetAmountSpentByClass $getAmountSpentByClass */
+        $getAmountSpentByClass = app(GetAmountSpentByClass::class);
+
+        $today = Carbon::now();  // TODO I don't think there's a timezone bug here, but still need to check
+        switch ($this->type) {
+            case self::TYPE_ONE_TIME:
+            case self::TYPE_POOL:
+                // Date from before we were using quickbooks to catch everything until now
+                $startDate = Carbon::createFromDate(2019, 1, 1);
+                $endDate = $today;
+                break;
+            case self::TYPE_RECURRING_MONTHLY:
+                $startDate = $today->startOfMonth();
+                $endDate = $today->endOfMonth();
+                break;
+            case self::TYPE_RECURRING_YEARLY:
+                $startDate = $today->startOfYear();
+                $endDate = $today->endOfYear();
+                break;
+            default:
+                throw new \Exception("Unknown budget type $this->type");
+        }
+
+        $quickBooksCurrentlyUsed = $getAmountSpentByClass->execute($this->quickbooks_class_id, $startDate, $endDate);
+
+        if($this->type == self::TYPE_POOL) {
+            // For a pool, the "spend" we just fetched is the negative of the amount we have available to use. i.e if
+            // the "amount spent" retrieved above is -700.00 then that means our pool has $700.00 it can use. If our
+            // allocated amount is $1,000.00 we can consider that $300.00 used. To make the math easier almost
+            // everywhere else, we calculate how much we've "used" based on how much is allocated. The only other place
+            // we have to care about this is when updating the allocated_amount field.
+            $quickBooksCurrentlyUsed = $this->allocated_amount + $quickBooksCurrentlyUsed;
+        }
+
+        if (abs($quickBooksCurrentlyUsed - $currentlyUsed) < 0.01) {
+            $this->currently_used = $quickBooksCurrentlyUsed;
+            $this->save();
+            // TODO Trigger any "go update the cards" stuff here?
+        }
+    }
+
+    protected function allocated_amount(): Attribute
+    {
+        return Attribute::make(
+            get: fn(float $value) => $value,
+            set: function(float $value, array $attributes) {
+                $result = ['allocated_amount' => $value];
+
+                // In a pool, the amount available to use is constant when the allocated amount changes. To compensate
+                // for that, we need to increase the currently used amount if our allocated amount increases and decrease
+                // it if the allocated amount decreases.
+                if($this->type == self::TYPE_POOL) {
+                    $currentAllocated = $attributes['allocated_amount'];
+
+                    $result['currently_used'] = ($value - $currentAllocated) + $currentAllocated;
+                }
+                return $result;
+            }
+        );
+    }
+
+    /**
+     * Returns the available amount that can be spent by the owner of this budget. If the budget is overdrawn, this will
+     * return 0. Returning a negative number could potentially affect other budgets when performing a sum of available
+     * money to spend across multiple budgets. This also handles a pool that has more money available to it than is
+     * allocated.
+     *
+     * @return float
+     */
+    public function getAvailableToSpendAttribute(): float
+    {
+        $canSpend = $this->allocated_amount - $this->available_to_spend;
+
+        // Less than a penny or already over budget? No spend for you!
+        if($canSpend < 0.01) {
+            return 0;
+        }
+
+        // Pools can only spend up to their allocated amount and no more
+        if($this->type == self::TYPE_POOL && $canSpend > $this->allocated_amount) {
+            return $this->allocated_amount;
+        }
+
+        return $canSpend;
+    }
+
+    public function owner(): MorphTo
+    {
+        return $this->morphTo();
+    }
+}

--- a/app/Models/Customer.php
+++ b/app/Models/Customer.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Carbon\Carbon;
 use Hashids\Hashids;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Notifications\Notifiable;
@@ -39,6 +40,7 @@ class Customer extends Model
 {
     use SoftDeletes;
     use Notifiable;
+    use HasFactory;
 
     public $incrementing = false;
 

--- a/app/Models/StripeCard.php
+++ b/app/Models/StripeCard.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+/**
+ * @property string id
+ * @property string cardholder_id
+ * @property string type
+ * @property string status
+ */
+class StripeCard extends Model
+{
+    use HasFactory;
+    use SoftDeletes;
+
+    protected $keyType = 'string';
+    public $incrementing = false;
+
+    protected $fillable = [
+        'id',
+        'cardholder_id',
+        'type',
+        'status',
+    ];
+}

--- a/app/Models/StripeCard.php
+++ b/app/Models/StripeCard.php
@@ -17,6 +17,13 @@ class StripeCard extends Model
     use HasFactory;
     use SoftDeletes;
 
+    public const TYPE_PHYSICAL = 'physical';
+    public const TYPE_VIRTUAL = 'virtual';
+
+    public const STATUS_INACTIVE = 'inactive';
+    public const STATUS_ACTIVE = 'active';
+    public const STATUS_CANCELED = 'canceled';
+
     protected $keyType = 'string';
     public $incrementing = false;
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -35,14 +35,14 @@ class AppServiceProvider extends ServiceProvider
             return new StripeClient(['api_key' => config('denhac.stripe.stripe_api_key')]);
         });
 
-        $this->app->bind(DataService::class, function () {
+        $this->app->scoped(DataService::class, function () {
             $dataService = DataService::Configure(QuickBooksAuthSettings::getDataServiceParameters());
             $dataService->setMinorVersion(53);  // So we can auto assign DocNumber's for journal entries
 
             return $dataService;
         });
 
-        $this->app->bind(OAuth2LoginHelper::class, function () {
+        $this->app->scoped(OAuth2LoginHelper::class, function () {
             /** @var DataService $dataService */
             $dataService = app(DataService::class);
 

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "ext-curl": "*",
         "ext-json": "*",
         "ext-openssl": "*",

--- a/database/factories/BudgetFactory.php
+++ b/database/factories/BudgetFactory.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Budget;
+use App\Models\Customer;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Budget>
+ */
+class BudgetFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $allocatedAmount = $this->faker->randomFloat(2, 500);  // Start at allocated $500
+        $currentlyUsed = $this->faker->randomFloat(2, 0, 500);  // Used max $500
+
+        return [
+            'quickbooks_class_id' => $this->faker->numerify('###################'),
+            'name' => $this->faker->name,
+            'type' => $this->faker->randomElement([
+                Budget::TYPE_ONE_TIME,
+                Budget::TYPE_RECURRING_MONTHLY,
+                Budget::TYPE_RECURRING_YEARLY,
+                Budget::TYPE_POOL,
+            ]),
+            'active' => true,
+            'allocated_amount' => $allocatedAmount,
+            'currently_used' => $currentlyUsed,
+        ];
+    }
+
+    public function owner(Customer $owner): static
+    {
+        return $this->state(function (array $attributes) use ($owner) {
+            return [
+                'owner_type' => $owner->getMorphClass(),
+                'owner_id' => $owner->getKey(),
+            ];
+        });
+    }
+
+    public function one_time(): static
+    {
+        return $this->state(function (array $attributes) {
+            return [
+                'type' => Budget::TYPE_ONE_TIME,
+            ];
+        });
+    }
+
+    public function monthly(): static
+    {
+        return $this->state(function (array $attributes) {
+            return [
+                'type' => Budget::TYPE_RECURRING_MONTHLY,
+            ];
+        });
+    }
+
+    public function yearly(): static
+    {
+        return $this->state(function (array $attributes) {
+            return [
+                'type' => Budget::TYPE_RECURRING_YEARLY,
+            ];
+        });
+    }
+
+    public function pool(): static
+    {
+        return $this->state(function (array $attributes) {
+            return [
+                'type' => Budget::TYPE_POOL,
+            ];
+        });
+    }
+}

--- a/database/factories/BudgetFactory.php
+++ b/database/factories/BudgetFactory.php
@@ -46,6 +46,15 @@ class BudgetFactory extends Factory
         });
     }
 
+    public function inactive(): static
+    {
+        return $this->state(function (array $attributes) {
+            return [
+                'active' => false,
+            ];
+        });
+    }
+
     public function one_time(): static
     {
         return $this->state(function (array $attributes) {

--- a/database/factories/CustomerFactory.php
+++ b/database/factories/CustomerFactory.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Database\Factories;
+
+use App\External\Stripe\StripeIdGenerator;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Customer>
+ */
+class CustomerFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'id' => $this->faker->randomNumber(),
+            'first_name' => $this->faker->firstName,
+            'last_name' => $this->faker->lastName,
+            'email' => $this->faker->email,
+            'username' => $this->faker->userName,
+            'member' => false,  // Several things depend on member status, so we don't randomize it.
+        ];
+    }
+
+    public function member(): static
+    {
+        return $this->state(function (array $attributes) {
+            return [
+                'member' => 'true',
+            ];
+        });
+    }
+
+    public function cardholder(): static
+    {
+        return $this->state(function (array $attributes) {
+            return [
+                'stripe_card_holder_id' => StripeIdGenerator::make('ich'),
+            ];
+        });
+    }
+}

--- a/database/factories/StripeCardFactory.php
+++ b/database/factories/StripeCardFactory.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Database\Factories;
+
+use App\External\Stripe\StripeIdGenerator;
+use App\Models\Customer;
+use App\Models\StripeCard;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\StripeCard>
+ */
+class StripeCardFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'id' => StripeIdGenerator::make('ic'),
+            'type' => StripeCard::TYPE_PHYSICAL,
+            'status' => StripeCard::STATUS_INACTIVE,
+        ];
+    }
+
+    public function cardholder(Customer $customer)
+    {
+        if(empty($customer->stripe_card_holder_id)) {
+            throw new \Exception("Stripe Card Holder id for customer was empty");
+        }
+        return $this->state(function (array $attributes) use($customer) {
+            return [
+                'cardholder_id' => $customer->stripe_card_holder_id,
+            ];
+        });
+    }
+
+    public function active(): static
+    {
+        return $this->state(function (array $attributes) {
+            return [
+                'status' => StripeCard::STATUS_ACTIVE,
+            ];
+        });
+    }
+
+    public function canceled(): static
+    {
+        return $this->state(function (array $attributes) {
+            return [
+                'status' => StripeCard::STATUS_CANCELED,
+            ];
+        });
+    }
+
+    public function virtual(): static
+    {
+        return $this->state(function (array $attributes) {
+            return [
+                'type' => StripeCard::TYPE_VIRTUAL,
+            ];
+        });
+    }
+}

--- a/database/migrations/2024_01_29_061509_create_budgets_table.php
+++ b/database/migrations/2024_01_29_061509_create_budgets_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('budgets', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+            $table->string('quickbooks_class_id');
+
+            $table->string('name');
+            $table->string('type');
+            $table->boolean('active');
+
+            $table->float('allocated_amount')->default(0);
+            $table->float('currently_used')->default(0);
+
+            $table->string('owner_type');
+            $table->string('owner_id');
+
+            $table->longText('notes');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('budgets');
+    }
+};

--- a/database/migrations/2024_01_29_061509_create_budgets_table.php
+++ b/database/migrations/2024_01_29_061509_create_budgets_table.php
@@ -26,7 +26,7 @@ return new class extends Migration
             $table->string('owner_type');
             $table->string('owner_id');
 
-            $table->longText('notes');
+            $table->longText('notes')->default('');
         });
     }
 

--- a/database/migrations/2024_04_08_205217_create_stripe_cards_table.php
+++ b/database/migrations/2024_04_08_205217_create_stripe_cards_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('stripe_cards', function (Blueprint $table) {
+            $table->string('id')->primary();
+            $table->string('cardholder_id')->index();
+            $table->string('type');
+            $table->string('status');
+
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('stripe_cards');
+    }
+};

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" backupStaticAttributes="false" bootstrap="vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false">
-  <coverage processUncoveredFiles="true">
-    <include>
-      <directory suffix=".php">./app</directory>
-    </include>
-  </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="false" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
   <testsuites>
     <testsuite name="Unit">
       <directory suffix="Test.php">./tests/Unit</directory>
@@ -24,4 +19,9 @@
     <env name="DB_DATABASE" value=":memory:"/>
     <env name="JOB_FAIL_NOTIFICATION_CHANNELS" value=""/>
   </php>
+  <source>
+    <include>
+      <directory suffix=".php">./app</directory>
+    </include>
+  </source>
 </phpunit>

--- a/tests/Helpers/ActionAssertion.php
+++ b/tests/Helpers/ActionAssertion.php
@@ -52,15 +52,20 @@ class ActionAssertion
         }
 
         $matchingJobs = $this->jobs
-            ->map(fn ($actionJob) => $actionJob['job'])
-            ->filter(fn ($actionJob) => $actionJob->displayName() == $this->cls)
+            ->map(fn($actionJob) => $actionJob['job'])
+            ->filter(fn($actionJob) => $actionJob->displayName() == $this->cls)
             ->filter(function ($job) use ($args) {
                 /** @var ActionJob $job */
-                if (is_null($args)) { // Anything goes
+                if (is_null($args) || count($args) == 0) { // Anything goes
                     return true;
                 }
 
                 $parameters = $job->parameters();
+
+                if (count($args) == 1 && is_callable($args[0])) {
+                    $callback = $args[0];
+                    return $callback(...$parameters);
+                }
 
                 $identical = new IsIdentical($args);
 
@@ -78,15 +83,15 @@ class ActionAssertion
         try {
             if ($timeType == self::TIMES_EXACTLY) {
                 $failureMessage = "Expected action to be queued exactly $timeValue $timePluralValue, "
-                    ."but it was queued $queueCount $timePluralQueueCount.";
+                    . "but it was queued $queueCount $timePluralQueueCount.";
                 Assert::assertEquals($timeValue, $queueCount, $failureMessage);
             } elseif ($timeType == self::TIMES_AT_LEAST) {
                 $failureMessage = "Expected action to be queued at least $timeValue $timePluralValue, "
-                    ."but it was queued $queueCount $timePluralQueueCount.";
+                    . "but it was queued $queueCount $timePluralQueueCount.";
                 Assert::assertGreaterThanOrEqual($timeValue, $queueCount, $failureMessage);
             } elseif ($timeType == self::TIMES_AT_MOST) {
                 $failureMessage = "Expected action to be queued at most $timeValue $timePluralValue, "
-                    ."but it was queued $queueCount $timePluralQueueCount.";
+                    . "but it was queued $queueCount $timePluralQueueCount.";
                 Assert::assertLessThanOrEqual($timeValue, $queueCount, $failureMessage);
             }
         } catch (AssertionFailedError $exception) {
@@ -97,7 +102,7 @@ class ActionAssertion
 
     private function printBacktrace()
     {
-        echo 'Assertion stacktrace:'.PHP_EOL;
+        echo 'Assertion stacktrace:' . PHP_EOL;
         $rootDir = dirname(app_path());
         foreach ($this->backtrace as $trace) {
             $filePath = $trace['file'];
@@ -106,7 +111,7 @@ class ActionAssertion
                 break;
             }
 
-            echo ' file://'.$filePath.':'.$trace['line'].PHP_EOL;
+            echo ' file://' . $filePath . ':' . $trace['line'] . PHP_EOL;
         }
     }
 

--- a/tests/Helpers/Stripe/StripeIssuing.php
+++ b/tests/Helpers/Stripe/StripeIssuing.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Helpers\Stripe;
+
+use Illuminate\Foundation\Testing\WithFaker;
+use Stripe\Issuing\Card;
+use Stripe\Issuing\Cardholder;
+use Stripe\StripeObject;
+use Stripe\Collection;
+
+trait StripeIssuing
+{
+    use WithFaker;
+
+    private const ID_CHARACTERS = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q',
+        'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+        'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',];
+
+    public function stripeId($prefix)
+    {
+        return $prefix . '_' . implode('', $this->faker->randomElements(self::ID_CHARACTERS, 24, true));
+    }
+
+    public function stripeIssuingCard(): Card
+    {
+        $card = new Card($this->stripeId('ic'));
+        $card->cardholder = $this->stripeIssuingCardHolder();
+        $card->status = $this->faker->randomElement(['active', 'cancelled', 'inactive']);
+        $card->type = $this->faker->randomElement(['physical', 'virtual']);
+
+        return $card;
+    }
+
+    public function stripeIssuingCardHolder(): Cardholder {
+        $cardHolder = new Cardholder($this->stripeId('ich'));
+
+        return $cardHolder;
+    }
+
+    public function stripeCollection(StripeObject ...$objects): Collection
+    {
+        return Collection::constructFrom([
+            'object' => 'list',
+            'data' => $objects,
+            'has_more' => false,
+        ], []);
+    }
+}

--- a/tests/Helpers/Stripe/StripeIssuing.php
+++ b/tests/Helpers/Stripe/StripeIssuing.php
@@ -16,7 +16,7 @@ trait StripeIssuing
         'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
         'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',];
 
-    public function stripeId($prefix)
+    public function stripeId($prefix): string
     {
         return $prefix . '_' . implode('', $this->faker->randomElements(self::ID_CHARACTERS, 24, true));
     }
@@ -31,8 +31,10 @@ trait StripeIssuing
         return $card;
     }
 
-    public function stripeIssuingCardHolder(): Cardholder {
+    public function stripeIssuingCardHolder(): Cardholder
+    {
         $cardHolder = new Cardholder($this->stripeId('ich'));
+        $cardHolder->phone_number = $this->faker->phoneNumber();
 
         return $cardHolder;
     }

--- a/tests/Helpers/Stripe/StripeIssuing.php
+++ b/tests/Helpers/Stripe/StripeIssuing.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Helpers\Stripe;
 
+use App\External\Stripe\StripeIdGenerator;
 use Illuminate\Foundation\Testing\WithFaker;
 use Stripe\Issuing\Card;
 use Stripe\Issuing\Cardholder;
@@ -12,18 +13,9 @@ trait StripeIssuing
 {
     use WithFaker;
 
-    private const ID_CHARACTERS = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q',
-        'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
-        'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',];
-
-    public function stripeId($prefix): string
-    {
-        return $prefix . '_' . implode('', $this->faker->randomElements(self::ID_CHARACTERS, 24, true));
-    }
-
     public function stripeIssuingCard(): Card
     {
-        $card = new Card($this->stripeId('ic'));
+        $card = new Card(StripeIdGenerator::make('ic'));
         $card->cardholder = $this->stripeIssuingCardHolder();
         $card->status = $this->faker->randomElement(['active', 'cancelled', 'inactive']);
         $card->type = $this->faker->randomElement(['physical', 'virtual']);
@@ -33,7 +25,7 @@ trait StripeIssuing
 
     public function stripeIssuingCardHolder(): Cardholder
     {
-        $cardHolder = new Cardholder($this->stripeId('ich'));
+        $cardHolder = new Cardholder(StripeIdGenerator::make('ich'));
         $cardHolder->phone_number = $this->faker->phoneNumber();
 
         return $cardHolder;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -74,7 +74,7 @@ abstract class TestCase extends BaseTestCase
         return new WaiverBuilder();
     }
 
-    public function subscriptionStatuses(): array
+    public static function subscriptionStatuses(): array
     {
         return [
             'Pending' => ['pending'],
@@ -89,7 +89,7 @@ abstract class TestCase extends BaseTestCase
         ];
     }
 
-    public function userMembershipStatuses(): array
+    public static function userMembershipStatuses(): array
     {
         return [
             'Active' => ['active'],

--- a/tests/Unit/Actions/QuickBooks/PullCurrentlyUsedAmountForBudgetFromQuickBooksTest.php
+++ b/tests/Unit/Actions/QuickBooks/PullCurrentlyUsedAmountForBudgetFromQuickBooksTest.php
@@ -46,8 +46,8 @@ class PullCurrentlyUsedAmountForBudgetFromQuickBooksTest extends TestCase
             'last_name' => $this->faker->lastName(),
         ]);
 
-        $today = Carbon::today();
-        $this->startOfBudgetTracking = Carbon::create(2019);
+        $today = Carbon::today('PST');
+        $this->startOfBudgetTracking = Carbon::create(2019, tz: 'PST');
         $this->endOfToday = $today->copy()->endOfDay();
         $this->startOfMonth = $today->copy()->startOfMonth();
         $this->endOfMonth = $today->copy()->endOfMonth();

--- a/tests/Unit/Actions/QuickBooks/PullCurrentlyUsedAmountForBudgetFromQuickBooksTest.php
+++ b/tests/Unit/Actions/QuickBooks/PullCurrentlyUsedAmountForBudgetFromQuickBooksTest.php
@@ -53,6 +53,8 @@ class PullCurrentlyUsedAmountForBudgetFromQuickBooksTest extends TestCase
         $this->endOfMonth = $today->copy()->endOfMonth();
         $this->startOfYear = $today->copy()->startOfYear();
         $this->endOfYear = $today->copy()->endOfYear();
+
+        Budget::setExtraBufferAmount(0);  // No buffer for these tests
     }
 
     /** @test */

--- a/tests/Unit/Actions/QuickBooks/PullCurrentlyUsedAmountForBudgetFromQuickBooksTest.php
+++ b/tests/Unit/Actions/QuickBooks/PullCurrentlyUsedAmountForBudgetFromQuickBooksTest.php
@@ -1,0 +1,267 @@
+<?php
+
+namespace Tests\Unit\Actions\QuickBooks;
+
+use App\Actions\QuickBooks\GetAmountSpentByClass;
+use App\Actions\QuickBooks\PullCurrentlyUsedAmountForBudgetFromQuickBooks;
+use App\Models\Budget;
+use App\Models\Customer;
+use Carbon\Carbon;
+use Mockery\MockInterface;
+use Tests\TestCase;
+
+class PullCurrentlyUsedAmountForBudgetFromQuickBooksTest extends TestCase
+{
+    private const ONE_TIME_CLASS_ID = 1234;
+    private const POOL_CLASS_ID = 5678;
+    private const MONTHLY_CLASS_ID = 9123;
+    private const YEARLY_CLASS_ID = 4802;
+
+    private PullCurrentlyUsedAmountForBudgetFromQuickBooks $pullCurrentlyUsedAmountForBudgetFromQuickBooks;
+    private GetAmountSpentByClass|MockInterface $getAmountSpentByClass;
+
+    private Customer $customer;
+
+    private Carbon $startOfBudgetTracking;
+    private Carbon $endOfToday;
+    private Carbon $startOfMonth;
+    private Carbon $endOfMonth;
+    private Carbon $startOfYear;
+    private Carbon $endOfYear;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->getAmountSpentByClass = $this->mock(GetAmountSpentByClass::class);
+
+        $this->pullCurrentlyUsedAmountForBudgetFromQuickBooks = app(PullCurrentlyUsedAmountForBudgetFromQuickBooks::class);
+
+        $this->customer = Customer::create([
+            'id' => $this->faker->randomNumber(),
+            'username' => $this->faker->userName(),
+            'member' => true,
+            'email' => $this->faker->email(),
+            'first_name' => $this->faker->firstName(),
+            'last_name' => $this->faker->lastName(),
+        ]);
+
+        $today = Carbon::today();
+        $this->startOfBudgetTracking = Carbon::create(2019);
+        $this->endOfToday = $today->copy()->endOfDay();
+        $this->startOfMonth = $today->copy()->startOfMonth();
+        $this->endOfMonth = $today->copy()->endOfMonth();
+        $this->startOfYear = $today->copy()->startOfYear();
+        $this->endOfYear = $today->copy()->endOfYear();
+    }
+
+    /** @test */
+    public function one_time_budget_is_measured_against_the_start_of_our_budget_tracking(): void
+    {
+        /** @var Budget $budget */
+        $budget = Budget::create([
+            'quickbooks_class_id' => self::ONE_TIME_CLASS_ID,
+            'name' => 'One time Budget',
+            'type' => Budget::TYPE_ONE_TIME,
+            'active' => true,
+            'owner_type' => Customer::getActualClassNameForMorph(Customer::class),
+            'owner_id' => $this->customer->id,
+            'allocated_amount' => 1000,
+            'currently_used' => 20,
+        ]);
+
+        $this->assertEquals(980, $budget->available_to_spend);  // Sanity check
+
+        $this->getAmountSpentByClass
+            ->expects('execute')
+            ->withArgs(function(...$args) {
+                return $args[0] == self::ONE_TIME_CLASS_ID &&
+                    $args[1] == $this->startOfBudgetTracking &&
+                    $args[2] == $this->endOfToday;
+            })
+            ->andReturn(600);
+
+        $this->pullCurrentlyUsedAmountForBudgetFromQuickBooks->execute($budget);
+
+        $budget->refresh();  // While the action probably modified this object, refreshing ensures it saved it to the DB
+
+        $this->assertEquals(1000, $budget->allocated_amount);
+        $this->assertEquals(600, $budget->currently_used);
+        $this->assertEquals(400, $budget->available_to_spend);
+    }
+
+    /** @test */
+    public function pool_budget_is_measured_against_the_start_of_our_budget_tracking(): void
+    {
+        /** @var Budget $budget */
+        $budget = Budget::create([
+            'quickbooks_class_id' => self::POOL_CLASS_ID,
+            'name' => 'Pool Budget',
+            'type' => Budget::TYPE_POOL,
+            'active' => true,
+            'owner_type' => Customer::getActualClassNameForMorph(Customer::class),
+            'owner_id' => $this->customer->id,
+            'allocated_amount' => 1000,
+            'currently_used' => 300,
+        ]);
+
+        $this->assertEquals(700, $budget->available_to_spend);  // Sanity check
+
+        $this->getAmountSpentByClass
+            ->expects('execute')
+            ->withArgs(function(...$args) {
+                return $args[0] == self::POOL_CLASS_ID &&
+                    $args[1] == $this->startOfBudgetTracking &&
+                    $args[2] == $this->endOfToday;
+            })
+            ->andReturn(-400);  // We have made $400 compared to our break even point
+
+        $this->pullCurrentlyUsedAmountForBudgetFromQuickBooks->execute($budget);
+
+        $budget->refresh();  // While the action probably modified this object, refreshing ensures it saved it to the DB
+
+        $this->assertEquals(1000, $budget->allocated_amount);
+        $this->assertEquals(600, $budget->currently_used);
+        $this->assertEquals(400, $budget->available_to_spend);
+    }
+
+    /** @test */
+    public function pool_budget_is_zero_if_our_spend_is_positive(): void
+    {
+        /** @var Budget $budget */
+        $budget = Budget::create([
+            'quickbooks_class_id' => self::POOL_CLASS_ID,
+            'name' => 'Pool Budget',
+            'type' => Budget::TYPE_POOL,
+            'active' => true,
+            'owner_type' => Customer::getActualClassNameForMorph(Customer::class),
+            'owner_id' => $this->customer->id,
+            'allocated_amount' => 1000,
+            'currently_used' => 300,
+        ]);
+
+        $this->assertEquals(700, $budget->available_to_spend);  // Sanity check
+
+        $this->getAmountSpentByClass
+            ->expects('execute')
+            ->withArgs(function(...$args) {
+                return $args[0] == self::POOL_CLASS_ID &&
+                    $args[1] == $this->startOfBudgetTracking &&
+                    $args[2] == $this->endOfToday;
+            })
+            ->andReturn(30);  // We have spent $30 that we don't have compared to our pool
+
+        $this->pullCurrentlyUsedAmountForBudgetFromQuickBooks->execute($budget);
+
+        $budget->refresh();  // While the action probably modified this object, refreshing ensures it saved it to the DB
+
+        $this->assertEquals(1000, $budget->allocated_amount);
+        $this->assertEquals(1030, $budget->currently_used);
+        $this->assertEquals(0, $budget->available_to_spend);
+    }
+
+    /** @test */
+    public function pool_budget_is_maxed_out_at_allocated(): void
+    {
+        /** @var Budget $budget */
+        $budget = Budget::create([
+            'quickbooks_class_id' => self::POOL_CLASS_ID,
+            'name' => 'Pool Budget',
+            'type' => Budget::TYPE_POOL,
+            'active' => true,
+            'owner_type' => Customer::getActualClassNameForMorph(Customer::class),
+            'owner_id' => $this->customer->id,
+            'allocated_amount' => 1000,
+            'currently_used' => 300,
+        ]);
+
+        $this->assertEquals(700, $budget->available_to_spend);  // Sanity check
+
+        $this->getAmountSpentByClass
+            ->expects('execute')
+            ->withArgs(function(...$args) {
+                return $args[0] == self::POOL_CLASS_ID &&
+                    $args[1] == $this->startOfBudgetTracking &&
+                    $args[2] == $this->endOfToday;
+            })
+            ->andReturn(-1030);  // We have made $1030 compared to our break even point
+
+        $this->pullCurrentlyUsedAmountForBudgetFromQuickBooks->execute($budget);
+
+        $budget->refresh();  // While the action probably modified this object, refreshing ensures it saved it to the DB
+
+        $this->assertEquals(1000, $budget->allocated_amount);
+        $this->assertEquals(0, $budget->currently_used);
+        $this->assertEquals(1000, $budget->available_to_spend);
+    }
+
+    /** @test */
+    public function monthly_budget_is_tracked_against_start_and_end_of_month(): void
+    {
+        /** @var Budget $budget */
+        $budget = Budget::create([
+            'quickbooks_class_id' => self::MONTHLY_CLASS_ID,
+            'name' => 'Pool Budget',
+            'type' => Budget::TYPE_RECURRING_MONTHLY,
+            'active' => true,
+            'owner_type' => Customer::getActualClassNameForMorph(Customer::class),
+            'owner_id' => $this->customer->id,
+            'allocated_amount' => 300,
+            'currently_used' => 150,
+        ]);
+
+        $this->assertEquals(150, $budget->available_to_spend);  // Sanity check
+
+        $this->getAmountSpentByClass
+            ->expects('execute')
+            ->withArgs(function(...$args) {
+                return $args[0] == self::MONTHLY_CLASS_ID &&
+                    $args[1] == $this->startOfMonth &&
+                    $args[2] == $this->endOfMonth;
+            })
+            ->andReturn(200);
+
+        $this->pullCurrentlyUsedAmountForBudgetFromQuickBooks->execute($budget);
+
+        $budget->refresh();  // While the action probably modified this object, refreshing ensures it saved it to the DB
+
+        $this->assertEquals(300, $budget->allocated_amount);
+        $this->assertEquals(200, $budget->currently_used);
+        $this->assertEquals(100, $budget->available_to_spend);
+    }
+
+    /** @test */
+    public function monthly_yearly_is_tracked_against_start_and_end_of_year(): void
+    {
+        /** @var Budget $budget */
+        $budget = Budget::create([
+            'quickbooks_class_id' => self::YEARLY_CLASS_ID,
+            'name' => 'Pool Budget',
+            'type' => Budget::TYPE_RECURRING_YEARLY,
+            'active' => true,
+            'owner_type' => Customer::getActualClassNameForMorph(Customer::class),
+            'owner_id' => $this->customer->id,
+            'allocated_amount' => 500,
+            'currently_used' => 150,
+        ]);
+
+        $this->assertEquals(350, $budget->available_to_spend);  // Sanity check
+
+        $this->getAmountSpentByClass
+            ->expects('execute')
+            ->withArgs(function(...$args) {
+                return $args[0] == self::YEARLY_CLASS_ID &&
+                    $args[1] == $this->startOfYear &&
+                    $args[2] == $this->endOfYear;
+            })
+            ->andReturn(300);
+
+        $this->pullCurrentlyUsedAmountForBudgetFromQuickBooks->execute($budget);
+
+        $budget->refresh();  // While the action probably modified this object, refreshing ensures it saved it to the DB
+
+        $this->assertEquals(500, $budget->allocated_amount);
+        $this->assertEquals(300, $budget->currently_used);
+        $this->assertEquals(200, $budget->available_to_spend);
+    }
+}

--- a/tests/Unit/Actions/Stripe/UpdateAllStripeCardsFromBudgetsTest.php
+++ b/tests/Unit/Actions/Stripe/UpdateAllStripeCardsFromBudgetsTest.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace Tests\Unit\Actions\Stripe;
+
+use App\Actions\Stripe\SetIssuingBalanceToValue;
+use App\Actions\Stripe\UpdateAllStripeCardsFromBudgets;
+use App\Actions\Stripe\UpdateSpendingLimitsOnCard;
+use App\External\Stripe\SpendingControls;
+use App\Models\Budget;
+use App\Models\Customer;
+use App\Models\StripeCard;
+use Illuminate\Support\Facades\Queue;
+use Tests\AssertsActions;
+use Tests\TestCase;
+
+class UpdateAllStripeCardsFromBudgetsTest extends TestCase
+{
+    use AssertsActions;
+
+    public UpdateAllStripeCardsFromBudgets $actionUnderTest;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+
+        $this->actionUnderTest = app(UpdateAllStripeCardsFromBudgets::class);
+    }
+
+    protected static function matchesAuth(SpendingControls $spendingControls, float $amountInPennies): bool
+    {
+        $stripeObject = $spendingControls->stripeObject();
+        return isset($stripeObject->spending_limits) &&
+            count($stripeObject->spending_limits) == 1 &&
+            $stripeObject->spending_limits[0]['interval'] == 'per_authorization' &&
+            $stripeObject->spending_limits[0]['amount'] == $amountInPennies;
+    }
+
+    /** @test */
+    public function inactive_budget_with_customer_owner(): void
+    {
+        /** @var Customer $customer */
+        $customer = Customer::factory()->member()->cardholder()->create();
+        /** @var StripeCard $stripeCard */
+        $stripeCard = StripeCard::factory()->cardholder($customer)->active()->create();
+        /** @var Budget $budget */
+        Budget::factory()->owner($customer)->inactive()->create();
+
+        $this->actionUnderTest->execute();
+
+        $this->assertAction(UpdateSpendingLimitsOnCard::class)
+            ->with(fn(...$args) => $stripeCard->is($args[0]) && self::matchesAuth($args[1], 1))
+            ->once();
+
+        $this->assertAction(SetIssuingBalanceToValue::class)
+            ->never();
+    }
+
+    /** @test */
+    public function budget_with_customer_owner(): void
+    {
+        /** @var Customer $customer */
+        $customer = Customer::factory()->member()->cardholder()->create();
+        /** @var StripeCard $stripeCard */
+        $stripeCard = StripeCard::factory()->cardholder($customer)->active()->create();
+        /** @var Budget $budget */
+        $budget = Budget::factory()->owner($customer)->create();
+
+        $this->actionUnderTest->execute();
+
+        $neededIssuingBalance = $budget->available_to_spend;
+        $neededIssuingBalancePennies = round($neededIssuingBalance * 100);
+
+        $this->assertAction(UpdateSpendingLimitsOnCard::class)
+            ->with(fn(...$args) => $stripeCard->is($args[0]) && self::matchesAuth($args[1], $neededIssuingBalancePennies))
+            ->once();
+
+        $this->assertAction(SetIssuingBalanceToValue::class)
+            ->with(fn(...$args) => $args[0] == $neededIssuingBalancePennies)
+            ->once();
+    }
+
+    /** @test */
+    public function budget_with_customer_owner_with_no_physical_card(): void
+    {
+        /** @var Customer $customer */
+        $customer = Customer::factory()->member()->cardholder()->create();
+        Budget::factory()->owner($customer)->create();
+
+        $this->actionUnderTest->execute();
+
+        $this->assertAction(UpdateSpendingLimitsOnCard::class)
+            ->never();
+
+        $this->assertAction(SetIssuingBalanceToValue::class)
+            ->never();
+    }
+
+    /** @test */
+    public function budget_with_customer_owner_with_inactive_card(): void
+    {
+        /** @var Customer $customer */
+        $customer = Customer::factory()->member()->cardholder()->create();
+        /** @var StripeCard $stripeCard */
+        $stripeCard = StripeCard::factory()->cardholder($customer)->create();
+        /** @var Budget $budget */
+        Budget::factory()->owner($customer)->create();
+
+        $this->actionUnderTest->execute();
+
+        $this->assertAction(UpdateSpendingLimitsOnCard::class)
+            ->with(fn(...$args) => $stripeCard->is($args[0]) && self::matchesAuth($args[1], 1))
+            ->once();
+
+        $this->assertAction(SetIssuingBalanceToValue::class)
+            ->never();
+    }
+
+    /** @test */
+    public function budget_with_customer_owner_with_canceled_card(): void
+    {
+        /** @var Customer $customer */
+        $customer = Customer::factory()->member()->cardholder()->create();
+        /** @var StripeCard $stripeCard */
+        StripeCard::factory()->cardholder($customer)->canceled()->create();
+        /** @var Budget $budget */
+        Budget::factory()->owner($customer)->create();
+
+        $this->actionUnderTest->execute();
+
+        $this->assertAction(UpdateSpendingLimitsOnCard::class)
+            ->never();  // Don't even bother doing an update for this card
+
+        $this->assertAction(SetIssuingBalanceToValue::class)
+            ->never();
+    }
+
+    /** @test */
+    public function budget_with_customer_owner_who_is_not_member(): void
+    {
+        /** @var Customer $customer */
+        $customer = Customer::factory()->cardholder()->create();
+        /** @var StripeCard $stripeCard */
+        $stripeCard = StripeCard::factory()->cardholder($customer)->active()->create();
+        /** @var Budget $budget */
+        Budget::factory()->owner($customer)->create();
+
+        $this->actionUnderTest->execute();
+
+        $this->assertAction(UpdateSpendingLimitsOnCard::class)
+            ->with(fn(...$args) => $stripeCard->is($args[0]) && self::matchesAuth($args[1], 1))
+            ->once();
+
+        $this->assertAction(SetIssuingBalanceToValue::class)
+            ->never();
+    }
+
+    /** @test */
+    public function budget_with_customer_owner_who_only_has_a_virtual_card(): void
+    {
+        /** @var Customer $customer */
+        $customer = Customer::factory()->member()->cardholder()->create();
+        /** @var StripeCard $stripeCard */
+        $stripeCard = StripeCard::factory()->cardholder($customer)->virtual()->active()->create();
+        /** @var Budget $budget */
+        $budget = Budget::factory()->owner($customer)->create();
+
+        $this->actionUnderTest->execute();
+
+        $this->assertAction(UpdateSpendingLimitsOnCard::class)
+            ->with(fn(...$args) => $stripeCard->is($args[0]) && self::matchesAuth($args[1], 1))
+            ->once();
+
+        $this->assertAction(SetIssuingBalanceToValue::class)
+            ->never();
+    }
+
+    /** @test */
+    public function budget_with_customer_owner_with_no_cardholder_id(): void
+    {
+        /** @var Customer $customer */
+        $customer = Customer::factory()->member()->create();
+        /** @var Budget $budget */
+        Budget::factory()->owner($customer)->create();
+
+        $this->actionUnderTest->execute();
+
+        $this->assertAction(UpdateSpendingLimitsOnCard::class)
+            ->never();
+
+        $this->assertAction(SetIssuingBalanceToValue::class)
+            ->never();
+    }
+}

--- a/tests/Unit/Actions/Stripe/UpdateCardsFromSourceTest.php
+++ b/tests/Unit/Actions/Stripe/UpdateCardsFromSourceTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Tests\Unit\Actions\Stripe;
+
+use App\Actions\Stripe\UpdateCardsFromSource;
+use App\Models\StripeCard;
+use Mockery\MockInterface;
+use Stripe\Service\Issuing\CardService;
+use Stripe\Service\Issuing\IssuingServiceFactory;
+use Stripe\StripeClient;
+use Tests\Helpers\Stripe\StripeIssuing;
+use Tests\TestCase;
+
+class UpdateCardsFromSourceTest extends TestCase
+{
+    use StripeIssuing;
+
+    private UpdateCardsFromSource $updateCardsFromSource;
+
+    private MockInterface|StripeClient $stripeClient;
+    private MockInterface|IssuingServiceFactory $issuing;
+    private MockInterface|CardService $cards;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->stripeClient = $this->mock(StripeClient::class);
+        $this->issuing = $this->mock(IssuingServiceFactory::class);
+        $this->stripeClient->issuing = $this->issuing;
+
+        $this->cards = $this->mock(CardService::class);
+        $this->issuing->cards = $this->cards;
+
+        $this->updateCardsFromSource = app(UpdateCardsFromSource::class);
+    }
+
+    /** @test */
+    public function polling_for_the_list_of_cards_creates_new_card_entries(): void
+    {
+        $newCard = $this->stripeIssuingCard();
+        $this->cards->expects('all')
+            ->andReturns($this->stripeCollection($newCard));
+
+        $this->assertEmpty(StripeCard::all());
+
+        $this->updateCardsFromSource->execute();
+
+        $cardModels = StripeCard::all();
+        $this->assertEquals(1, $cardModels->count());
+
+        $cardModel = $cardModels->first();
+        $this->assertEquals($newCard->id, $cardModel->id);
+        $this->assertEquals($newCard->cardholder->id, $cardModel->cardholder_id);
+        $this->assertEquals($newCard->type, $cardModel->type);
+        $this->assertEquals($newCard->status, $cardModel->status);
+    }
+
+    /** @test */
+    public function polling_for_the_list_of_cards_only_updates_the_fields_that_can_change(): void
+    {
+        $newCard = $this->stripeIssuingCard();
+        $this->cards->expects('all')
+            ->andReturns($this->stripeCollection($newCard));
+
+        $this->assertEmpty(StripeCard::all());
+
+        $this->updateCardsFromSource->execute();
+
+        $cardModels = StripeCard::all();
+        $this->assertEquals(1, $cardModels->count());
+
+        // At this point, we have our one created stripe model. Now begins the testing.
+
+        // Once these fields are set on creation, they should never change so we should be sure to never respond to a
+        // change.
+        $originalCardHolder = $newCard->cardholder;
+        $newCard->cardholder = $this->stripeIssuingCardHolder();
+
+        $this->updateCardsFromSource->execute();
+
+        $cardModel = $cardModels->first();
+        $this->assertEquals($newCard->id, $cardModel->id);
+        $this->assertEquals($originalCardHolder, $cardModel->cardholder_id);
+        $this->assertEquals($newCard->type, $cardModel->type);
+        $this->assertEquals($newCard->status, $cardModel->status);
+    }
+}

--- a/tests/Unit/Actions/Stripe/UpdateStripeCardsFromSourceTest.php
+++ b/tests/Unit/Actions/Stripe/UpdateStripeCardsFromSourceTest.php
@@ -17,20 +17,18 @@ class UpdateStripeCardsFromSourceTest extends TestCase
 
     private UpdateStripeCardsFromSource $updateCardsFromSource;
 
-    private MockInterface|StripeClient $stripeClient;
-    private MockInterface|IssuingServiceFactory $issuing;
     private MockInterface|CardService $cards;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->stripeClient = $this->mock(StripeClient::class);
-        $this->issuing = $this->mock(IssuingServiceFactory::class);
-        $this->stripeClient->issuing = $this->issuing;
+        $stripeClient = $this->mock(StripeClient::class);
+        $issuing = $this->mock(IssuingServiceFactory::class);
+        $stripeClient->issuing = $issuing;
 
         $this->cards = $this->mock(CardService::class);
-        $this->issuing->cards = $this->cards;
+        $issuing->cards = $this->cards;
 
         $this->updateCardsFromSource = app(UpdateStripeCardsFromSource::class);
     }

--- a/tests/Unit/Actions/Stripe/UpdateStripeCardsFromSourceTest.php
+++ b/tests/Unit/Actions/Stripe/UpdateStripeCardsFromSourceTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Unit\Actions\Stripe;
 
-use App\Actions\Stripe\UpdateCardsFromSource;
+use App\Actions\Stripe\UpdateStripeCardsFromSource;
 use App\Models\StripeCard;
 use Mockery\MockInterface;
 use Stripe\Service\Issuing\CardService;
@@ -11,11 +11,11 @@ use Stripe\StripeClient;
 use Tests\Helpers\Stripe\StripeIssuing;
 use Tests\TestCase;
 
-class UpdateCardsFromSourceTest extends TestCase
+class UpdateStripeCardsFromSourceTest extends TestCase
 {
     use StripeIssuing;
 
-    private UpdateCardsFromSource $updateCardsFromSource;
+    private UpdateStripeCardsFromSource $updateCardsFromSource;
 
     private MockInterface|StripeClient $stripeClient;
     private MockInterface|IssuingServiceFactory $issuing;
@@ -32,14 +32,14 @@ class UpdateCardsFromSourceTest extends TestCase
         $this->cards = $this->mock(CardService::class);
         $this->issuing->cards = $this->cards;
 
-        $this->updateCardsFromSource = app(UpdateCardsFromSource::class);
+        $this->updateCardsFromSource = app(UpdateStripeCardsFromSource::class);
     }
 
     /** @test */
     public function polling_for_the_list_of_cards_creates_new_card_entries(): void
     {
         $newCard = $this->stripeIssuingCard();
-        $this->cards->expects('all')
+        $this->cards->allows('all')
             ->andReturns($this->stripeCollection($newCard));
 
         $this->assertEmpty(StripeCard::all());
@@ -60,7 +60,7 @@ class UpdateCardsFromSourceTest extends TestCase
     public function polling_for_the_list_of_cards_only_updates_the_fields_that_can_change(): void
     {
         $newCard = $this->stripeIssuingCard();
-        $this->cards->expects('all')
+        $this->cards->allows('all')
             ->andReturns($this->stripeCollection($newCard));
 
         $this->assertEmpty(StripeCard::all());
@@ -81,7 +81,7 @@ class UpdateCardsFromSourceTest extends TestCase
 
         $cardModel = $cardModels->first();
         $this->assertEquals($newCard->id, $cardModel->id);
-        $this->assertEquals($originalCardHolder, $cardModel->cardholder_id);
+        $this->assertEquals($originalCardHolder->id, $cardModel->cardholder_id);
         $this->assertEquals($newCard->type, $cardModel->type);
         $this->assertEquals($newCard->status, $cardModel->status);
     }

--- a/tests/Unit/External/Stripe/TestSpendingControls.php
+++ b/tests/Unit/External/Stripe/TestSpendingControls.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Unit\External\Stripe;
+
+use App\External\Stripe\SpendingControls;
+use App\External\Stripe\SpendingLimits;
+use Tests\TestCase;
+
+class TestSpendingControls extends TestCase
+{
+    // TODO Add correct logic for setting allowed/blocked categories and merchant countries should we ever need it.
+
+    /** @test */
+    public function default_spending_controls(): void
+    {
+        $controls = new SpendingControls();
+
+        $object = $controls->stripeObject();
+
+        self::assertFalse(isset($object->allowed_categories));
+        self::assertFalse(isset($object->allowed_merchant_countries));
+        self::assertFalse(isset($object->blocked_categories));
+        self::assertFalse(isset($object->blocked_merchant_countries));
+        self::assertFalse(isset($object->spending_limits));
+    }
+
+    /** @test */
+    public function with_spending_limits(): void
+    {
+        $limits = (new SpendingLimits(100_00))->daily();
+        $controls = (new SpendingControls())->spending_limits($limits);
+
+        $object = $controls->stripeObject();
+
+        self::assertFalse(isset($object->allowed_categories));
+        self::assertFalse(isset($object->allowed_merchant_countries));
+        self::assertFalse(isset($object->blocked_categories));
+        self::assertFalse(isset($object->blocked_merchant_countries));
+        self::assertTrue(isset($object->spending_limits));
+        self::assertEquals([$limits->stripeObject()], $object->spending_limits);
+    }
+
+    /** @test */
+    public function with_multiple_spending_limits(): void
+    {
+        $limit_a = (new SpendingLimits(100_00))->daily();
+        $limit_b = (new SpendingLimits(300_00))->yearly();
+        $controls = (new SpendingControls())->spending_limits($limit_a, $limit_b);
+
+        $object = $controls->stripeObject();
+
+        self::assertFalse(isset($object->allowed_categories));
+        self::assertFalse(isset($object->allowed_merchant_countries));
+        self::assertFalse(isset($object->blocked_categories));
+        self::assertFalse(isset($object->blocked_merchant_countries));
+        self::assertTrue(isset($object->spending_limits));
+        self::assertEquals([$limit_a->stripeObject(), $limit_b->stripeObject()], $object->spending_limits);
+    }
+}

--- a/tests/Unit/External/Stripe/TestSpendingLimits.php
+++ b/tests/Unit/External/Stripe/TestSpendingLimits.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Tests\Unit\External\Stripe;
+
+use App\External\Stripe\SpendingLimits;
+use Tests\TestCase;
+
+class TestSpendingLimits extends TestCase
+{
+    /** @test */
+    public function default_spending_limits(): void
+    {
+        $limits = new SpendingLimits();
+
+        $object = $limits->stripeObject();
+
+        self::assertTrue(isset($object->amount));
+        self::assertEquals(500_00, $object->amount);
+        self::assertTrue(isset($object->interval));
+        self::assertEquals("all_time", $object->interval);
+    }
+
+    /** @test */
+    public function constructor_spending_limit(): void
+    {
+        $limits = new SpendingLimits(100_00);
+
+        $object = $limits->stripeObject();
+
+        self::assertTrue(isset($object->amount));
+        self::assertEquals(100_00, $object->amount);
+        self::assertTrue(isset($object->interval));
+        self::assertEquals("all_time", $object->interval);
+    }
+
+    /** @test */
+    public function daily_interval(): void
+    {
+        $limits = (new SpendingLimits())->daily();
+
+        $object = $limits->stripeObject();
+
+        self::assertTrue(isset($object->amount));
+        self::assertEquals(500_00, $object->amount);
+        self::assertTrue(isset($object->interval));
+        self::assertEquals("daily", $object->interval);
+    }
+
+    /** @test */
+    public function weekly_interval(): void
+    {
+        $limits = (new SpendingLimits())->weekly();
+
+        $object = $limits->stripeObject();
+
+        self::assertTrue(isset($object->amount));
+        self::assertEquals(500_00, $object->amount);
+        self::assertTrue(isset($object->interval));
+        self::assertEquals("weekly", $object->interval);
+    }
+
+    /** @test */
+    public function monthly_interval(): void
+    {
+        $limits = (new SpendingLimits())->monthly();
+
+        $object = $limits->stripeObject();
+
+        self::assertTrue(isset($object->amount));
+        self::assertEquals(500_00, $object->amount);
+        self::assertTrue(isset($object->interval));
+        self::assertEquals("monthly", $object->interval);
+    }
+
+    /** @test */
+    public function yearly_interval(): void
+    {
+        $limits = (new SpendingLimits())->yearly();
+
+        $object = $limits->stripeObject();
+
+        self::assertTrue(isset($object->amount));
+        self::assertEquals(500_00, $object->amount);
+        self::assertTrue(isset($object->interval));
+        self::assertEquals("yearly", $object->interval);
+    }
+
+    /** @test */
+    public function per_authorization_interval(): void
+    {
+        $limits = (new SpendingLimits())->per_authorization();
+
+        $object = $limits->stripeObject();
+
+        self::assertTrue(isset($object->amount));
+        self::assertEquals(500_00, $object->amount);
+        self::assertTrue(isset($object->interval));
+        self::assertEquals("per_authorization", $object->interval);
+    }
+}

--- a/tests/Unit/Models/BudgetTest.php
+++ b/tests/Unit/Models/BudgetTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Budget;
+use App\Models\Customer;
+use Database\Factories\BudgetFactory;
+use Tests\TestCase;
+
+class BudgetTest extends TestCase
+{
+    private Customer $customer;
+
+    private Budget $oneTimeBudget;
+    private Budget $monthlyBudget;
+    private Budget $yearlyBudget;
+    private Budget $poolBudget;
+
+    private const ALLOCATED_AMOUNT = 500;
+    private const CURRENTLY_USED = 200;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->oneTimeBudget = $this->makeBudget()->one_time()->create();
+        $this->monthlyBudget = $this->makeBudget()->monthly()->create();
+        $this->yearlyBudget = $this->makeBudget()->yearly()->create();
+        $this->poolBudget = $this->makeBudget()->pool()->create();
+    }
+
+    private function makeBudget(): BudgetFactory
+    {
+        if (empty($this->customer)) {
+            $this->customer = Customer::factory()->create();
+        }
+
+        /** @var BudgetFactory $factory */
+        $factory = Budget::factory();
+        return $factory
+            ->owner($this->customer)
+            ->state([
+                'allocated_amount' => self::ALLOCATED_AMOUNT,
+                'currently_used' => self::CURRENTLY_USED,
+            ]);
+    }
+
+    /** @test */
+    public function budget_available_with_no_extra(): void
+    {
+        Budget::setExtraBufferAmount(0);
+
+        $expectedAvailable = self::ALLOCATED_AMOUNT - self::CURRENTLY_USED;
+        self::assertEquals($expectedAvailable, $this->oneTimeBudget->available_to_spend);
+        self::assertEquals($expectedAvailable, $this->monthlyBudget->available_to_spend);
+        self::assertEquals($expectedAvailable, $this->yearlyBudget->available_to_spend);
+        self::assertEquals($expectedAvailable, $this->poolBudget->available_to_spend);
+    }
+
+    /** @test */
+    public function budget_available_with_extra(): void
+    {
+        Budget::setExtraBufferAmount(10);
+
+        $expectedAvailable = self::ALLOCATED_AMOUNT - self::CURRENTLY_USED;
+        $expectedAvailableWithExtra = $expectedAvailable + 10;
+        self::assertEquals($expectedAvailableWithExtra, $this->oneTimeBudget->available_to_spend);
+        self::assertEquals($expectedAvailableWithExtra, $this->monthlyBudget->available_to_spend);
+        self::assertEquals($expectedAvailableWithExtra, $this->yearlyBudget->available_to_spend);
+        self::assertEquals($expectedAvailable, $this->poolBudget->available_to_spend);
+    }
+}


### PR DESCRIPTION
The goal for this was to lay the groundwork for our automated budget management systems. I've introduced the `Budget` and `StripeCard` models. `StripeCard` is currently set to sync hourly. That entire table gets updated from Stripe's API. Originally this was just to backfill the data, but it may prove useful to always get new cards this way as well.

The `Budget` class has no UI as of yet. We have a few options there:
- We could manually update these (ie I teach @Agent123983 how to access the command line interface and build these budget objects).
- We essentially don't do anything based on budgets yet. (keep our top-up at $1k, and don't adjust spending limits)

Next chunks of work (approximately in order):
- UI/UX for @Agent123983 in Slack
- QuickBooks integration (adjusting parent class depending on if the budget is active or not)
- Basic transactions support (Basically a model for transactions done on the stripe cards. End goal will be to take transactions into account when setting issuing balance for a given card as well as sending a message in Slack when we get a new transaction in.)
- More complete transaction flow (TBD all the details, but essentially trying to make it easier to do things like attach receipts)
- Improve flow for getting people set up with Stripe (Up to this point, we'd need to make the cardholder and cards manually and THEN create the budget against those cards. So the Slack UI/UX might change at this point. We also need to handle all the nonsense like "are we sending this card to the right address" and "here's how you activate the card" and such.)
- Support more than just "budget is attached to person with physical card"