### PR TITLE
Add display name to customers table

### DIFF
--- a/app/Models/Customer.php
+++ b/app/Models/Customer.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Carbon\Carbon;
 use Hashids\Hashids;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -33,6 +34,7 @@ use Illuminate\Support\Collection;
  * @property Collection equipmentTrainer
  * @property string member_code
  * @property bool id_checked
+ * @property string display_name
  * @property ?string stripe_card_holder_id
  * @property ?int id_was_checked_by_id
  * @property ?Customer idWasCheckedBy
@@ -135,8 +137,8 @@ class Customer extends Model
     public function isATrainer()
     {
         return $this->equipmentTrainer()
-            ->where('status', 'active')
-            ->count() > 0;
+                ->where('status', 'active')
+                ->count() > 0;
     }
 
     public function routeNotificationForMail(Notification $notification): string
@@ -179,5 +181,12 @@ class Customer extends Model
         $membershipWaiverTemplateId = Waiver::getValidMembershipWaiverId();
 
         return "https://app.waiverforever.com/pending/{$membershipWaiverTemplateId}?name-first_name-2={$this->first_name}&name-last_name-2={$this->last_name}&email-email-3={$this->email}&checkbox-checked-4=true";
+    }
+
+    public function displayName(): Attribute
+    {
+        return Attribute::make(
+            get: fn(?string $value) => $value ?? "{$this->first_name} {$this->last_name}"
+        );
     }
 }

--- a/app/Models/Customer.php
+++ b/app/Models/Customer.php
@@ -186,7 +186,7 @@ class Customer extends Model
     public function displayName(): Attribute
     {
         return Attribute::make(
-            get: fn(?string $value) => $value ?? "{$this->first_name} {$this->last_name}"
+            get: fn(?string $value) => $value ?? "$this->first_name $this->last_name"
         );
     }
 }

--- a/app/Projectors/CustomerProjector.php
+++ b/app/Projectors/CustomerProjector.php
@@ -114,6 +114,7 @@ final class CustomerProjector extends Projector
         $customerModel->username = $customer_json['username'];
         $customerModel->first_name = $customer_json['first_name'];
         $customerModel->last_name = $customer_json['last_name'];
+        $customerModel->display_name = $customer_json['display_name'] ?? null;
         $customerModel->github_username = $this->getMetadataField($customer_json, 'github_username');
         $customerModel->slack_id = $this->getMetadataField($customer_json, 'access_slack_id');
         $customerModel->birthday = $this->getMetadataFieldDate($customer_json, 'account_birthday');

--- a/database/migrations/2025_06_01_045445_add_display_name_to_customers_table.php
+++ b/database/migrations/2025_06_01_045445_add_display_name_to_customers_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('customers', function (Blueprint $table) {
+            $table->string('display_name')->nullable()
+                ->after('last_name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('customers', function (Blueprint $table) {
+            $table->dropColumn('display_name');
+        });
+    }
+};

--- a/tests/Helpers/Wordpress/CustomerBuilder.php
+++ b/tests/Helpers/Wordpress/CustomerBuilder.php
@@ -110,6 +110,13 @@ class CustomerBuilder extends BaseBuilder
         return $this->meta_data('_access_temporary_code', $code);
     }
 
+    public function display_name($display_name): static
+    {
+        $this->data['display_name'] = $display_name;
+
+        return $this;
+    }
+
     public function __set(string $name, $value): void
     {
         switch ($name) {

--- a/tests/Unit/Projectors/CustomerProjectorTest.php
+++ b/tests/Unit/Projectors/CustomerProjectorTest.php
@@ -112,7 +112,7 @@ class CustomerProjectorTest extends TestCase
         $builder->first_name = $this->faker->firstName();
         $builder->last_name = $this->faker->lastName();
         $builder->github_username = $this->faker->userName();
-        $builder->slack_id = 'U'.$this->faker->randomNumber();
+        $builder->slack_id = 'U' . $this->faker->randomNumber();
         $builder->birthday = $this->faker->date();
         $builder->access_card_temporary_code = strval($this->faker->randomNumber(6));
 
@@ -268,5 +268,34 @@ class CustomerProjectorTest extends TestCase
         $customer = Customer::find($builder->id);
 
         $this->assertTrue($customer->id_checked);
+    }
+
+    /** @test */
+    public function display_name_is_set_from_json(): void
+    {
+        $display_name = $this->faker->name;
+        $builder = $this->customer()->display_name($display_name);
+
+        $this->assertNull(Customer::find($builder->id));
+
+        event(new CustomerCreated($builder->toArray()));
+
+        /** @var Customer $customer */
+        $customer = Customer::find($builder->id);
+        $this->assertEquals($display_name, $customer->display_name);
+    }
+
+    /** @test */
+    public function display_name_defaults_to_first_and_last_name(): void
+    {
+        $builder = $this->customer();
+
+        $this->assertNull(Customer::find($builder->id));
+
+        event(new CustomerCreated($builder->toArray()));
+
+        /** @var Customer $customer */
+        $customer = Customer::find($builder->id);
+        $this->assertEquals("$builder->first_name $builder->last_name", $customer->display_name);
     }
 }


### PR DESCRIPTION
We've added the `display_name` attribute to the webhook customer created/updated events. Now, any time someone's user account is updated or they change their display name, it will be reflected in other areas. Our primary goal is to use it in the auto bay reservation system which will be a future PR. Users will have their display name default to their first and last name, but can submit their preferred display name and it will be updated. Eventually, we should use this name for things such as the equipment training dropdown.

Note that this is not the same as their Slack display name as we don't really have control over that. We have some work planned in the future to make them synonymous and handle updates automatically, but we didn't want to block the garage auto bay work.