### PR TITLE
Auto select only available equipment

### DIFF
--- a/app/External/Slack/Modals/EquipmentAuthorization.php
+++ b/app/External/Slack/Modals/EquipmentAuthorization.php
@@ -20,13 +20,11 @@ class EquipmentAuthorization implements ModalInterface
     use RespondsToBlockActions;
     use HasExternalOptions;
 
-    private const EQUIPMENT_DROPDOWN = 'equipment-dropdown';
+    private const string EQUIPMENT_DROPDOWN = 'equipment-dropdown';
 
-    private const PERSON_DROPDOWN = 'person-dropdown';
+    private const string PERSON_DROPDOWN = 'person-dropdown';
 
-    private const TRAINER_CHECK = 'trainer-check';
-
-    private const USER_CHECK = 'user-check';
+    private const string TRAINER_CHECK = 'trainer-check';
 
     public function __construct(?Customer $user)
     {
@@ -39,7 +37,9 @@ class EquipmentAuthorization implements ModalInterface
                 $equipmentOptions->append(
                     Kit::option(
                         text: $equipment->name,
-                        value: "equipment-$equipment->id"
+                        value: "equipment-$equipment->id",
+                        // If the user only has one item they can train on, pre-select it.
+                        initial: $trainingList->count() == 1
                     )
                 );
             }
@@ -132,7 +132,6 @@ class EquipmentAuthorization implements ModalInterface
         return [
             self::blockActionUpdate(self::EQUIPMENT_DROPDOWN),
             self::blockActionUpdate(self::PERSON_DROPDOWN),
-            self::blockActionDoNothing(self::USER_CHECK),
             self::blockActionDoNothing(self::TRAINER_CHECK),
         ];
     }

--- a/app/External/Slack/Modals/MembershipOptionsModal.php
+++ b/app/External/Slack/Modals/MembershipOptionsModal.php
@@ -146,6 +146,12 @@ class MembershipOptionsModal implements ModalInterface
             $optionSet->append(Kit::option('Create Trainable Equipment', self::CREATE_TRAINABLE_EQUIPMENT_VALUE));
         }
 
+        // If there's only 1 option, automatically select it.
+        if($optionSet->count() == 1) {
+            $option = $optionSet->offsetGet(0);
+            $option->initial(true);
+        }
+
         return $optionSet;
     }
 }


### PR DESCRIPTION
This fixes #44.

It also improves #43, by auto selecting the only option in the membership options modal if you only have one option. I decided having the extra screen where you just hit submit was both easier technically and less confusing for the user on the event they got a second item in that list and the behavior changed.