### PR TITLE
Help with duplicate submissions for equipment training

### DIFF
--- a/app/External/Slack/Modals/CreateTrainableEquipment.php
+++ b/app/External/Slack/Modals/CreateTrainableEquipment.php
@@ -78,7 +78,7 @@ class CreateTrainableEquipment implements ModalInterface
 
                 $mappedToSimilarity = $equipmentNames->map(fn($name) => [
                     'name' => $name,
-                    'value' => similar_text(Str::lower($name), $equipmentName)
+                    'value' => similar_text(Str::lower($name), Str::lower($equipmentName))
                 ]);
 
                 $maxValue = $mappedToSimilarity->max('value');

--- a/app/External/Slack/Modals/CreateTrainableEquipment.php
+++ b/app/External/Slack/Modals/CreateTrainableEquipment.php
@@ -235,7 +235,7 @@ class CreateTrainableEquipment implements ModalInterface
         $values = $request->payload()['view']['state']['values'];
         $initialTrainerValue = self::getInitialTrainerOption($values);
 
-        $equipmentName = $values[self::EQUIPMENT_NAME][self::EQUIPMENT_NAME] ?? null;
+        $equipmentName = $values[self::EQUIPMENT_NAME][self::EQUIPMENT_NAME]['value'] ?? null;
 
         $modal = new CreateTrainableEquipment(
             $request->customer(),


### PR DESCRIPTION
It's apparently really hard to get really good similarity checking in a way that balances catching duplicates but isn't so specific as to not fail on minor mismatches. The `similar_text` function seemed to do pretty well. This PR will show up to 5 of the most similar entries. It doesn't order them by most similar to least similar, but rather figures out the highest scoring value and shows up to 5 entries with that score. We could theoretically miss things still, but testing the duplicate entries I saw and cleaned up already, this does seem to catch them for the most part. (It might catch forge vs foundry, for example, but I couldn't test that as the entries had already been deleted)

It also doesn't prevent you from submitting a training item. All it does is display that list as you type. I'm not sure rejecting it is a good idea as there's no clear cut off of "this is totally a duplicate.

Fixes #70.