### PR TITLE
Fixing external membership options lookup

### DIFF
--- a/app/External/Slack/Modals/SelectAMemberModal.php
+++ b/app/External/Slack/Modals/SelectAMemberModal.php
@@ -74,6 +74,12 @@ class SelectAMemberModal implements ModalInterface
     public static function getExternalOptions(SlackRequest $request): OptionsResult
     {
         $filterValue = $request->payload()['value'] ?? null;
+
+        // Treat empty string also as null for consistency.
+        if($filterValue == "") {
+            $filterValue = null;
+        }
+
         $optionSet = Kit::optionSet();
 
         $customers = Customer::all();
@@ -88,6 +94,9 @@ class SelectAMemberModal implements ModalInterface
 
             if ($customer->member) {
                 $text = "$name (Member)";
+            } else if (is_null($filterValue)) {
+                // When showing the initial list, do not show non-members
+                continue;
             } else {
                 $text = "$name (Not a Member)";
             }

--- a/app/Http/Controllers/SlackOptionsController.php
+++ b/app/Http/Controllers/SlackOptionsController.php
@@ -6,6 +6,10 @@ use App\External\Slack\ClassFinder;
 use App\External\Slack\Modals\HasExternalOptions;
 use App\Http\Requests\SlackRequest;
 use ReflectionClass;
+use SlackPhp\BlockKit\Collections\OptionGroupCollection;
+use SlackPhp\BlockKit\Collections\OptionSet;
+use SlackPhp\BlockKit\Parts\OptionGroup;
+use SlackPhp\BlockKit\Surfaces\OptionsResult;
 
 class SlackOptionsController extends Controller
 {
@@ -35,6 +39,67 @@ class SlackOptionsController extends Controller
             throw new \Exception('Requested external options from Slack modal that does not implement the external options trait.');
         }
 
-        return $modalClassName::getExternalOptions($request);
+        /** @var HasExternalOptions $modalClassName */
+
+        $optionsResult = $modalClassName::getExternalOptions($request);
+
+        $this->limitOptionsResults($optionsResult);
+
+        return $optionsResult;
+    }
+
+    private function limitOptionsResults(OptionsResult $optionsResult): void
+    {
+        // We can only have 100 top level options.
+        $optionsResult->options = $this->limitOptionSet($optionsResult->options);
+
+        $optionGroups = $optionsResult->optionGroups;
+        // We can only have 100 option groups, with 100 options each.
+        if($optionGroups->count() > 100) {
+            $newOptionGroups = OptionGroupCollection::new();
+
+            $counter = 0;
+            foreach($optionGroups->getIterator() as $component) {
+                $newOptionGroups->append($component);
+                $counter++;
+
+                if($counter == 100) {
+                    break;
+                }
+            }
+
+            $optionGroups = $newOptionGroups;
+        }
+
+        for ($i = 0; $i < $optionGroups->count(); $i++) {
+            /** @var OptionGroup $optionGroup */
+            $optionGroup = $optionGroups->offsetGet($i);
+
+            $optionGroup->options = $this->limitOptionSet($optionGroup->options);
+
+            $optionGroups->offsetSet($i, $optionGroup);
+        }
+    }
+
+    private function limitOptionSet(OptionSet $optionSet): OptionSet
+    {
+        // If we're below 100, we don't need to limit it
+        if($optionSet->count() <= 100) {
+            return $optionSet;
+        }
+
+        // There doesn't seem to be an easy way to access the internal components, but we can iterate over them.
+        $newOptionSet = OptionSet::new();
+        $counter = 0;
+        foreach($optionSet->getIterator() as $component) {
+            $newOptionSet->append($component);
+            $counter++;
+
+            if($counter == 100) {
+                break;
+            }
+        }
+
+        return $newOptionSet;
     }
 }


### PR DESCRIPTION
There were 2 issues. The first is the filter was an empty string which was causing everything to be filtered out. The second was that after we fixed the filter, the number of options we were returning was way more than what Slack wanted. We're now limiting the number of options that are returned.